### PR TITLE
Improve config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ To use rescrobbled, you'll need a Last.fm API key and secret. These can be obtai
 
 Rescrobbled expects a configuration file at `~/.config/rescrobbled/config.toml` with the following format:
 ```toml
-api-key = "Last.fm API key"
-api-secret = "Last.fm API secret"
-lb-token = "ListenBrainz API token" # optional
+lastfm-key = "Last.fm API key"
+lastfm-secret = "Last.fm API secret"
+listenbrainz-token = "ListenBrainz API token" # optional
 enable-notifications = false # optional
 min-play-time = 0 # optional; in seconds
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ api-key = "Last.fm API key"
 api-secret = "Last.fm API secret"
 lb-token = "ListenBrainz API token" # optional
 enable-notifications = false # optional
-min-play-time = { secs: 0, nanos: 0 } # optional
+min-play-time = 0 # optional; in seconds
 ```
 By default, track submission respects Last.fm's recommended behavior; songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using `min-play-time` you can override this.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,9 +29,15 @@ fn deserialize_duration_seconds<'de, D: Deserializer<'de>>(de: D) -> Result<Opti
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    pub api_key: String,
-    pub api_secret: String,
-    pub lb_token: Option<String>,
+    #[serde(alias = "api-key")]
+    pub lastfm_key: String,
+
+    #[serde(alias = "api-secret")]
+    pub lastfm_secret: String,
+
+    #[serde(alias = "lb-token")]
+    pub listenbrainz_token: Option<String>,
+
     pub enable_notifications: Option<bool>,
 
     #[serde(default, deserialize_with = "deserialize_duration_seconds")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,11 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use dirs;
 use std::fmt;
 use std::fs;
 use std::io;
 use std::time::Duration;
+
+use dirs;
 
 use serde::{Deserialize, Deserializer};
 
@@ -52,11 +53,18 @@ impl fmt::Display for ConfigError {
 }
 
 pub fn load_config() -> Result<Config, ConfigError> {
-    let mut path = dirs::config_dir().unwrap();
+    let mut path = dirs::config_dir()
+        .ok_or(ConfigError::Io(io::Error::new(io::ErrorKind::NotFound, "User config directory not found")))?;
+
     path.push("rescrobbled");
-    fs::create_dir_all(&path).expect("could not create config dir");
+
+    fs::create_dir_all(&path)
+        .map_err(|err| ConfigError::Io(err))?;
+
     path.push("config.toml");
-    let buffer = fs::read_to_string(&path).map_err(|err| ConfigError::Io(err))?;
+
+    let buffer = fs::read_to_string(&path)
+        .map_err(|err| ConfigError::Io(err))?;
 
     toml::from_str(&buffer)
         .map_err(|err| ConfigError::Format(format!("Could not parse config: {}", err)))

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,11 @@ use std::fs;
 use std::io;
 use std::time::Duration;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+
+fn deserialize_duration_seconds<'de, D: Deserializer<'de>>(de: D) -> Result<Option<Duration>, D::Error> {
+    Ok(Some(Duration::from_secs(u64::deserialize(de)?)))
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -29,6 +33,7 @@ pub struct Config {
     pub lb_token: Option<String>,
     pub enable_notifications: Option<bool>,
 
+    #[serde(default, deserialize_with = "deserialize_duration_seconds")]
     pub min_play_time: Option<Duration>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use rustfm_scrobble::Scrobbler;
-
 use std::process;
+
+use rustfm_scrobble::Scrobbler;
 
 mod auth;
 mod config;
@@ -28,11 +28,6 @@ fn main() {
         Ok(config) => config,
         Err(err) => {
             eprintln!("Error while loading config: {}", err);
-            eprintln!("\t$HOME/.config/rescrobbled/config.toml must be formatted as follows:");
-            eprintln!("\tapi-key = \"apikeystring\"");
-            eprintln!("\tapi-secret = \"apisecretstring\"");
-            eprintln!("\tlb-token = \"tokenuuid\"");
-            eprintln!("\tenable-notifications = true");
             process::exit(1);
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
         }
     };
 
-    let mut scrobbler = Scrobbler::new(config.api_key.clone(), config.api_secret.clone());
+    let mut scrobbler = Scrobbler::new(config.lastfm_key.clone(), config.lastfm_secret.clone());
 
     match auth::authenticate(&mut scrobbler) {
         Ok(_) => println!("Authenticated with Last.fm successfully!"),

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -174,7 +174,7 @@ pub fn run(config: &Config, scrobbler: &Scrobbler) {
                         Ok(_) => println!("Track submitted to Last.fm successfully"),
                         Err(err) => eprintln!("Failed to submit track to Last.fm: {}", err),
                     }
-                    if let Some(ref token) = config.lb_token {
+                    if let Some(ref token) = config.listenbrainz_token {
                         let listen = Listen {
                             artist: &artist[..],
                             track: &title[..],
@@ -203,7 +203,7 @@ pub fn run(config: &Config, scrobbler: &Scrobbler) {
             println!("----");
             println!("Now playing: {} - {} ({})", artist, title, album);
 
-            if config.enable_notifications.unwrap_or_default() {
+            if config.enable_notifications.unwrap_or(false) {
                 Notification::new()
                     .summary(&title)
                     .body(&format!("{} - {}", &artist, &album))
@@ -211,13 +211,15 @@ pub fn run(config: &Config, scrobbler: &Scrobbler) {
                     .show()
                     .unwrap();
             }
+
             let scrobble = Scrobble::new(artist.clone(), title.clone(), album.clone());
 
             match scrobbler.now_playing(scrobble) {
                 Ok(_) => println!("Status updated on Last.fm successfully"),
                 Err(err) => eprintln!("Failed to update status on Last.fm: {}", err),
             }
-            if let Some(ref token) = config.lb_token {
+
+            if let Some(ref token) = config.listenbrainz_token {
                 let listen = Listen {
                     artist: &artist[..],
                     track: &title[..],


### PR DESCRIPTION
- The `min-play-time` option now simply takes the number of seconds, instead of an object containing `secs` and `nanos`.
- API token options have been renamed (old names still work, though):
  - `api-key` => `lastfm-key`
  - `api-secret` => `lastfm-secret`
  - `lb-token` => `listenbrainz-token`
- Better config error handling