### PR TITLE
Add optional player whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,17 @@ To use rescrobbled, you'll need a Last.fm API key and secret. These can be obtai
 
 Rescrobbled expects a configuration file at `~/.config/rescrobbled/config.toml` with the following format:
 ```toml
+# required
+
 lastfm-key = "Last.fm API key"
 lastfm-secret = "Last.fm API secret"
-listenbrainz-token = "ListenBrainz API token" # optional
-enable-notifications = false # optional
-min-play-time = 0 # optional; in seconds
-player-whitelist = [ "Player MPRIS identity" ] # optional; if empty or ommitted, will allow all players
+
+# optional
+
+listenbrainz-token = "ListenBrainz API token"
+enable-notifications = false
+min-play-time = 0 # in seconds
+player-whitelist = [ "Player MPRIS identity" ] # if empty or ommitted, will allow all players
 ```
 By default, track submission respects Last.fm's recommended behavior; songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using `min-play-time` you can override this.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ lastfm-secret = "Last.fm API secret"
 listenbrainz-token = "ListenBrainz API token" # optional
 enable-notifications = false # optional
 min-play-time = 0 # optional; in seconds
+player-whitelist = [ "Player MPRIS identity" ] # optional; if empty or ommitted, will allow all players
 ```
 By default, track submission respects Last.fm's recommended behavior; songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using `min-play-time` you can override this.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use std::fs;
 use std::io;
 use std::time::Duration;
+use std::collections::HashSet;
 
 use dirs;
 
@@ -42,6 +43,8 @@ pub struct Config {
 
     #[serde(default, deserialize_with = "deserialize_duration_seconds")]
     pub min_play_time: Option<Duration>,
+
+    pub player_whitelist: Option<HashSet<String>>,
 }
 
 pub enum ConfigError {


### PR DESCRIPTION
Add an optional config item, `player-whitelist`. If present, this will allow you to filter media players by their MPRIS identity.

Example:
```toml
player-whitelist = [ "Spotify", "some-other-mpris-player" ]
```
This will ignore all players other than `Spotify` and `some-other-mpris-player`.

Closes #21.