### PR TITLE
Make Last.fm scrobbling optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@
 - Improved usage instructions
 - Renamed config options (old names still supported)
 - Added music player whitelisting (by MPRIS identity or D-Bus bus name)
+- Made Last.fm scrobbling optional
 
 ## v0.1.0
 
-Initial release. Open issues:
-- Does not handle single-song repeat well: only scrobbles songs once
-- Might get stuck searching for players after a long idle time when running as a systemd service
+Initial release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # rescrobbled
 
-Rescrobbled is a music scrobbler daemon written in Rust. Among other things, due to sharing a Spotify account (I know, I know), I needed a way to scrobble to [Last.fm](https://last.fm) without connecting the Spotify account to my Last.fm account. Rescrobbled detects active media players running on D-Bus using `MPRIS`, automatically updates "now playing" status, and scrobbles songs as they play. [ListenBrainz](https://listenbrainz.org) is also (optionally) supported.
+Rescrobbled is a music scrobbler daemon written in Rust. Among other things, due to sharing a Spotify account (I know, I know), I needed a way to scrobble to [Last.fm](https://last.fm) without connecting the Spotify account to my Last.fm account.
+Rescrobbled detects active media players running on D-Bus using `MPRIS`, automatically updates "now playing" status, and scrobbles songs to Last.fm or [ListenBrainz](https://listenbrainz.org) as they play.
 
 ## How to install and use
 
@@ -10,24 +11,21 @@ Alternatively you can install from source using `cargo install --path .` from th
 
 There is also an [Arch Linux AUR package](https://aur.archlinux.org/packages/rescrobbled-git/) by [brycied00d](https://github.com/brycied00d). (I do not maintain this so I cannot provide support for it.)
 
-To use rescrobbled, you'll need a Last.fm API key and secret. These can be obtained [here](https://www.last.fm/api/account/create).
+To use rescrobbled with Last.fm, you'll need a Last.fm API key and secret. These can be obtained [here](https://www.last.fm/api/account/create). To use ListenBrainz, you'll need a user token which can be found [here](https://listenbrainz.org/profile/).
 
 ### Configuration
 
 Rescrobbled expects a configuration file at `~/.config/rescrobbled/config.toml` with the following format:
 ```toml
-# required
-
 lastfm-key = "Last.fm API key"
 lastfm-secret = "Last.fm API secret"
-
-# optional
-
 listenbrainz-token = "ListenBrainz API token"
 enable-notifications = false
 min-play-time = 0 # in seconds
 player-whitelist = [ "Player MPRIS identity" ] # if empty or ommitted, will allow all players
 ```
+All settings are optional, although rescrobbled isn't very useful with neither Last.fm nor ListenBrainz credentials. ;-)
+
 By default, track submission respects Last.fm's recommended behavior; songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using `min-play-time` you can override this.
 
 ### Running rescrobbled

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,10 +33,10 @@ fn deserialize_duration_seconds<'de, D: Deserializer<'de>>(
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     #[serde(alias = "api-key")]
-    pub lastfm_key: String,
+    pub lastfm_key: Option<String>,
 
     #[serde(alias = "api-secret")]
-    pub lastfm_secret: String,
+    pub lastfm_secret: Option<String>,
 
     #[serde(alias = "lb-token")]
     pub listenbrainz_token: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,15 +32,24 @@ fn main() {
         }
     };
 
-    let mut scrobbler = Scrobbler::new(&config.lastfm_key, &config.lastfm_secret);
-
-    match auth::authenticate(&mut scrobbler) {
-        Ok(_) => println!("Authenticated with Last.fm successfully!"),
-        Err(err) => {
-            eprintln!("Failed to authenticate with Last.fm: {}", err);
+    let scrobbler = match (&config.lastfm_key, &config.lastfm_secret) {
+        (Some(key), Some(secret)) => {
+            let mut scrobbler = Scrobbler::new(key, secret);
+            match auth::authenticate(&mut scrobbler) {
+                Ok(_) => println!("Authenticated with Last.fm successfully!"),
+                Err(err) => {
+                    eprintln!("Failed to authenticate with Last.fm: {}", err);
+                    process::exit(1);
+                }
+            }
+            Some(scrobbler)
+        }
+        (None, None) => None,
+        _ => {
+            eprintln!("Last.fm API key or API secret are missing");
             process::exit(1);
         }
-    }
+    };
 
-    mainloop::run(&config, &scrobbler);
+    mainloop::run(config, scrobbler);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,5 +51,9 @@ fn main() {
         }
     };
 
+    if scrobbler.is_none() && config.listenbrainz_token.is_none() {
+        eprintln!("Warning: both Last.fm and ListenBrainz API credentials are missing");
+    }
+
     mainloop::run(config, scrobbler);
 }

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -198,11 +198,12 @@ pub fn run(config: &Config, scrobbler: &Scrobbler) {
                         Ok(_) => println!("Track submitted to Last.fm successfully"),
                         Err(err) => eprintln!("Failed to submit track to Last.fm: {}", err),
                     }
+
                     if let Some(ref token) = config.listenbrainz_token {
                         let listen = Listen {
-                            artist: &artist[..],
-                            track: &title[..],
-                            album: &album[..],
+                            artist: &artist,
+                            track: &title,
+                            album: &album,
                         };
                         match listen.single(token) {
                             Ok(_) => println!("Track submitted to ListenBrainz successfully"),
@@ -231,7 +232,7 @@ pub fn run(config: &Config, scrobbler: &Scrobbler) {
                 Notification::new()
                     .summary(&title)
                     .body(&format!("{} - {}", &artist, &album))
-                    .timeout(Timeout::Milliseconds(6000)) //milliseconds
+                    .timeout(Timeout::Milliseconds(6000))
                     .show()
                     .unwrap();
             }
@@ -245,9 +246,9 @@ pub fn run(config: &Config, scrobbler: &Scrobbler) {
 
             if let Some(ref token) = config.listenbrainz_token {
                 let listen = Listen {
-                    artist: &artist[..],
-                    track: &title[..],
-                    album: &album[..],
+                    artist: &artist,
+                    track: &title,
+                    album: &album,
                 };
                 match listen.playing_now(token) {
                     Ok(_) => println!("Status updated on ListenBrainz successfully"),


### PR DESCRIPTION
You can now leave out Last.fm API credentials from the configuration file, making Last.fm scrobbling optional.