### PR TITLE
Filter script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Fixed a bug where a single song on repeat only scrobbled once
 - Rescrobbled now creates the config file if it doesn't exist
+- Added the `filter-script` config option:
+    - Rescrobbled will run this script to filter metadata before
+      submitting it to Last.fm and/or ListenBrainz
+    - The script receives artist, song title and album name on
+      consecutive lines of its standard input (in that order)
+    - It should produce filtered metadata on the corresponding
+      lines of its standard output
+    - Format might change in future updates, eg. to provide
+      additional metadata
 
 ## v0.2.0 (2020-08-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "notify-rust",
  "rustfm-scrobble",
  "serde",
+ "tempfile",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 dirs = "3"
 notify-rust = "4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -23,16 +23,22 @@ listenbrainz-token = "ListenBrainz API token"
 enable-notifications = false
 min-play-time = 0 # in seconds
 player-whitelist = [ "Player MPRIS identity" ] # if empty or ommitted, will allow all players
+filter-script = "path/to/script"
 ```
+
+All settings are optional, although rescrobbled isn't very useful with neither Last.fm nor ListenBrainz credentials. ;-)
+
+By default, track submission respects Last.fm's recommended behavior; songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using `min-play-time` you can override this.
 
 A CLI application like `playerctl` can be used to determine a player's MPRIS identity for the whitelist. To do so start playing a song and run the following command:
 ```
 playerctl --list-all
 ```
 
-All settings are optional, although rescrobbled isn't very useful with neither Last.fm nor ListenBrainz credentials. ;-)
-
-By default, track submission respects Last.fm's recommended behavior; songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using `min-play-time` you can override this.
+The `filter-script` will be run before submitting tracks to Last.fm and/or ListenBrainz.
+It receives the artist, song title and album name on consecutive lines of its standard input
+(in that order). The script should provide the filtered metadata on corresponding lines of its standard output.
+This can be used to clean up song names, for example removing "remastered" and similar suffixes.
 
 ### Running rescrobbled
 

--- a/config_template.toml
+++ b/config_template.toml
@@ -4,3 +4,4 @@
 # enable-notifications = false
 # min_play_time = 0
 # player_whitelist = []
+# filter-script = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ fn deserialize_duration_seconds<'de, D: Deserializer<'de>>(
     Ok(Some(Duration::from_secs(u64::deserialize(de)?)))
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     #[serde(alias = "api-key")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ pub struct Config {
     pub min_play_time: Option<Duration>,
 
     pub player_whitelist: Option<HashSet<String>>,
+
+    pub filter_script: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,79 @@
+use std::process::{Command, Stdio};
+use std::io::Write;
+
+use crate::config::Config;
+
+pub fn filter_metadata(config: &Config, artist: &str, title: &str, album: &str) -> Option<(String, String, String)> {
+    if config.filter_script.is_none() {
+        return None;
+    }
+
+    let child = Command::new(config.filter_script.as_ref().unwrap())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn();
+
+    let mut child = match child {
+        Ok(child) => child,
+        Err(err) => {
+            eprintln!("Failed to run filter script: {}", err);
+            return None;
+        }
+    };
+
+    let stdin = child.stdin.take();
+    let mut stdin = if let Some(stdin) = stdin {
+        stdin
+    } else {
+        eprintln!("Failed to get a stdin handle for the filter script");
+        return None;
+    };
+
+    let buffer = format!("{}\n{}\n{}\n", artist, title, album);
+    if let Err(err) = stdin.write_all(buffer.as_bytes()) {
+        eprintln!("Failed to write metadata to filter script stdin: {}", err);
+        return None;
+    }
+
+    // Close child's stdin to prevent endless waiting
+    drop(stdin);
+
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!("Failed to retrieve output from filter script: {}", err);
+            return None;
+        }
+    };
+
+    if !output.status.success() {
+        eprint!("Filter script returned unsuccessfully ");
+        if let Some(status) = output.status.code() {
+            eprintln!("with status {}", status);
+        } else {
+            eprintln!("without status");
+        }
+
+        match String::from_utf8(output.stderr) {
+            Ok(output) => eprintln!("Stderr: {}", output),
+            Err(err) => eprintln!("Stderr is not UTF-8: {}", err),
+        }
+
+        return None;
+    }
+
+    let output = match String::from_utf8(output.stdout) {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!("Filter script stdout is not UTF-8: {}", err);
+            return None;
+        }
+    };
+
+    let mut output = output.split('\n');
+    Some((
+        output.next()?.to_string(),
+        output.next()?.to_string(),
+        output.next()?.to_string(),
+    ))
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,9 +1,14 @@
-use std::process::{Command, Stdio};
 use std::io::Write;
+use std::process::{Command, Stdio};
 
 use crate::config::Config;
 
-pub fn filter_metadata(config: &Config, artist: &str, title: &str, album: &str) -> Option<(String, String, String)> {
+pub fn filter_metadata(
+    config: &Config,
+    artist: &str,
+    title: &str,
+    album: &str,
+) -> Option<(String, String, String)> {
     if config.filter_script.is_none() {
         return None;
     }
@@ -87,8 +92,7 @@ mod tests {
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
 
-        const FILTER_SCRIPT: &str =
-"#!/usr/bin/bash
+        const FILTER_SCRIPT: &str = "#!/usr/bin/bash
 read artist
 read title
 read album

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use rustfm_scrobble::Scrobbler;
 
 mod auth;
 mod config;
+mod filter;
 mod mainloop;
 mod player;
 

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -15,8 +15,8 @@
 
 use listenbrainz_rust::Listen;
 use mpris::{PlaybackStatus, PlayerFinder};
-use rustfm_scrobble::{Scrobble, Scrobbler};
 use notify_rust::{Notification, Timeout};
+use rustfm_scrobble::{Scrobble, Scrobbler};
 
 use std::process;
 use std::thread;
@@ -134,10 +134,13 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
                 let min_play_time = get_min_play_time(length, &config);
 
                 if length > MIN_LENGTH && current_play_time > min_play_time {
-                    let (filtered_artist, filtered_title, filtered_album) = filter_metadata(&config, artist, title, album)
-                        .unwrap_or_else(|| (artist.to_string(), title.to_string(), album.to_string()));
+                    let (filtered_artist, filtered_title, filtered_album) =
+                        filter_metadata(&config, artist, title, album).unwrap_or_else(|| {
+                            (artist.to_string(), title.to_string(), album.to_string())
+                        });
 
-                    let scrobble = Scrobble::new(&filtered_artist, &filtered_title, &filtered_album);
+                    let scrobble =
+                        Scrobble::new(&filtered_artist, &filtered_title, &filtered_album);
 
                     if let Some(ref scrobbler) = scrobbler {
                         match scrobbler.scrobble(&scrobble) {
@@ -176,15 +179,19 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
             previous_album.clear();
             previous_album.push_str(album);
 
-            let (filtered_artist, filtered_title, filtered_album) = filter_metadata(&config, artist, title, album)
-                        .unwrap_or_else(|| (artist.to_string(), title.to_string(), album.to_string()));
+            let (filtered_artist, filtered_title, filtered_album) =
+                filter_metadata(&config, artist, title, album)
+                    .unwrap_or_else(|| (artist.to_string(), title.to_string(), album.to_string()));
 
             timer = Instant::now();
             current_play_time = Duration::from_secs(0);
             scrobbled_current_song = false;
 
             println!("----");
-            println!("Now playing: {} - {} ({})", filtered_artist, filtered_title, filtered_album);
+            println!(
+                "Now playing: {} - {} ({})",
+                filtered_artist, filtered_title, filtered_album
+            );
 
             if config.enable_notifications.unwrap_or(false) {
                 Notification::new()

--- a/src/player.rs
+++ b/src/player.rs
@@ -16,7 +16,7 @@
 use std::thread;
 use std::time::Duration;
 
-use mpris::{Player, PlayerFinder, PlaybackStatus};
+use mpris::{PlaybackStatus, Player, PlayerFinder};
 
 use crate::config::Config;
 
@@ -52,8 +52,7 @@ fn bus_name<'p>(player: &'p Player) -> &'p str {
 fn is_whitelisted(config: &Config, player: &Player) -> bool {
     if let Some(ref whitelist) = config.player_whitelist {
         if !whitelist.is_empty() {
-            return whitelist.contains(player.identity())
-                || whitelist.contains(bus_name(player));
+            return whitelist.contains(player.identity()) || whitelist.contains(bus_name(player));
         }
     }
     true


### PR DESCRIPTION
Add the `filter-script` config option:
  - Rescrobbled will run this script to filter metadata before submitting it to Last.fm and/or ListenBrainz
  - The script receives artist, song title and album name on consecutive lines of its standard input (in that order)
  - It should produce filtered metadata on the corresponding lines of its standard output
  - Format might change in future updates, eg. to provide additional metadata