### PR TITLE
Allow ignoring tracks using the filter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The `filter-script` will be run before submitting tracks to Last.fm and/or Liste
 It receives the artist, song title and album name on consecutive lines of its standard input
 (in that order). The script should provide the filtered metadata on corresponding lines of its standard output.
 This can be used to clean up song names, for example removing "remastered" and similar suffixes.
+If the filter script does not return any output, the current track will be ignored.
+This allows you, for example, to prevent certain tracks or artists from being scrobbled.
 
 ### Running rescrobbled
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -22,7 +22,8 @@ pub fn filter_metadata(config: &Config, track: Track) -> Result<FilterResult, St
         .spawn()
         .map_err(|err| format!("Failed to run filter script: {}", err))?;
 
-    let mut stdin = child.stdin
+    let mut stdin = child
+        .stdin
         .take()
         .ok_or_else(|| "Failed to get a stdin handle for the filter script".to_owned())?;
 
@@ -62,7 +63,7 @@ pub fn filter_metadata(config: &Config, track: Track) -> Result<FilterResult, St
         (Some(artist), Some(title), Some(album)) => {
             Ok(FilterResult::Filtered(Track::new(artist, title, album)))
         }
-        _ => Ok(FilterResult::Ignored)
+        _ => Ok(FilterResult::Ignored),
     }
 }
 
@@ -95,7 +96,11 @@ echo \"Album=$album\"
 
         assert_eq!(
             filter_metadata(&config, Track::new("lorem", "ipsum", "dolor")),
-            Ok(FilterResult::Filtered(Track::new("Artist=lorem", "Title=ipsum", "Album=dolor")))
+            Ok(FilterResult::Filtered(Track::new(
+                "Artist=lorem",
+                "Title=ipsum",
+                "Album=dolor"
+            )))
         );
 
         // Script that produces no output should result in `FilterResult::Ignored`
@@ -121,7 +126,9 @@ true
 
         assert_eq!(
             filter_metadata(&config, Track::new("lorem", "ipsum", "dolor")),
-            Ok(FilterResult::NotFiltered(Track::new("lorem", "ipsum", "dolor")))
+            Ok(FilterResult::NotFiltered(Track::new(
+                "lorem", "ipsum", "dolor"
+            )))
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod config;
 mod filter;
 mod mainloop;
 mod player;
+mod track;
 
 use config::ConfigError;
 

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -23,7 +23,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::config::Config;
-use crate::filter::{FilterResult, filter_metadata};
+use crate::filter::{filter_metadata, FilterResult};
 use crate::player;
 use crate::track::Track;
 
@@ -123,13 +123,17 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
 
                 if length > MIN_LENGTH && current_play_time > min_play_time {
                     match filter_metadata(&config, current_track) {
-                        Ok(FilterResult::Filtered(track)) | Ok(FilterResult::NotFiltered(track)) => {
+                        Ok(FilterResult::Filtered(track))
+                        | Ok(FilterResult::NotFiltered(track)) => {
                             if let Some(ref scrobbler) = scrobbler {
-                                let scrobble = Scrobble::new(track.artist(), track.title(), track.album());
+                                let scrobble =
+                                    Scrobble::new(track.artist(), track.title(), track.album());
 
                                 match scrobbler.scrobble(&scrobble) {
                                     Ok(_) => println!("Track submitted to Last.fm successfully"),
-                                    Err(err) => eprintln!("Failed to submit track to Last.fm: {}", err),
+                                    Err(err) => {
+                                        eprintln!("Failed to submit track to Last.fm: {}", err)
+                                    }
                                 }
                             }
 
@@ -144,7 +148,10 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
                                         println!("Track submitted to ListenBrainz successfully");
                                     }
                                     Err(err) => {
-                                        eprintln!("Failed to submit track to ListenBrainz: {}", err);
+                                        eprintln!(
+                                            "Failed to submit track to ListenBrainz: {}",
+                                            err
+                                        );
                                     }
                                 }
                             }
@@ -172,7 +179,11 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
             if config.enable_notifications.unwrap_or(false) {
                 Notification::new()
                     .summary(&current_track.title())
-                    .body(&format!("{} - {}", current_track.artist(), current_track.album()))
+                    .body(&format!(
+                        "{} - {}",
+                        current_track.artist(),
+                        current_track.album()
+                    ))
                     .timeout(Timeout::Milliseconds(6000))
                     .show()
                     .unwrap();
@@ -181,7 +192,9 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
             println!("----");
             println!(
                 "Now playing: {} - {} ({})",
-                current_track.artist(), current_track.title(), current_track.album()
+                current_track.artist(),
+                current_track.title(),
+                current_track.album()
             );
 
             match filter_metadata(&config, current_track) {
@@ -202,7 +215,9 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
                         };
                         match listen.playing_now(token) {
                             Ok(_) => println!("Status updated on ListenBrainz successfully"),
-                            Err(err) => eprintln!("Failed to update status on ListenBrainz: {}", err),
+                            Err(err) => {
+                                eprintln!("Failed to update status on ListenBrainz: {}", err)
+                            }
                         }
                     }
                 }

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -23,8 +23,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::config::Config;
-use crate::filter::filter_metadata;
+use crate::filter::{FilterResult, filter_metadata};
 use crate::player;
+use crate::track::Track;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
@@ -56,9 +57,7 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
 
     println!("Found active player {}", player.identity());
 
-    let mut previous_artist = String::new();
-    let mut previous_title = String::new();
-    let mut previous_album = String::new();
+    let mut previous_track = Track::default();
 
     let mut timer = Instant::now();
     let mut current_play_time = Duration::from_secs(0);
@@ -75,9 +74,7 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
 
             println!("Found active player {}", player.identity());
 
-            previous_artist.clear();
-            previous_title.clear();
-            previous_album.clear();
+            previous_track.clear();
 
             timer = Instant::now();
             current_play_time = Duration::from_secs(0);
@@ -108,16 +105,7 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
             }
         };
 
-        let artist = metadata
-            .artists()
-            .as_ref()
-            .and_then(|artists| artists.first())
-            .map(|&artist| artist)
-            .unwrap_or("");
-
-        let title = metadata.title().unwrap_or("");
-
-        let album = metadata.album_name().unwrap_or("");
+        let current_track = Track::from_metadata(&metadata);
 
         let length = match metadata.length() {
             Some(length) => length,
@@ -129,39 +117,42 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
             }
         };
 
-        if artist == previous_artist && title == previous_title && album == previous_album {
+        if current_track == previous_track {
             if !scrobbled_current_song {
                 let min_play_time = get_min_play_time(length, &config);
 
                 if length > MIN_LENGTH && current_play_time > min_play_time {
-                    let (filtered_artist, filtered_title, filtered_album) =
-                        filter_metadata(&config, artist, title, album).unwrap_or_else(|| {
-                            (artist.to_string(), title.to_string(), album.to_string())
-                        });
+                    match filter_metadata(&config, current_track) {
+                        Ok(FilterResult::Filtered(track)) | Ok(FilterResult::NotFiltered(track)) => {
+                            if let Some(ref scrobbler) = scrobbler {
+                                let scrobble = Scrobble::new(track.artist(), track.title(), track.album());
 
-                    let scrobble =
-                        Scrobble::new(&filtered_artist, &filtered_title, &filtered_album);
+                                match scrobbler.scrobble(&scrobble) {
+                                    Ok(_) => println!("Track submitted to Last.fm successfully"),
+                                    Err(err) => eprintln!("Failed to submit track to Last.fm: {}", err),
+                                }
+                            }
 
-                    if let Some(ref scrobbler) = scrobbler {
-                        match scrobbler.scrobble(&scrobble) {
-                            Ok(_) => println!("Track submitted to Last.fm successfully"),
-                            Err(err) => eprintln!("Failed to submit track to Last.fm: {}", err),
-                        }
-                    }
-
-                    if let Some(ref token) = config.listenbrainz_token {
-                        let listen = Listen {
-                            artist: &filtered_artist,
-                            track: &filtered_title,
-                            album: &filtered_album,
-                        };
-                        match listen.single(token) {
-                            Ok(_) => println!("Track submitted to ListenBrainz successfully"),
-                            Err(err) => {
-                                eprintln!("Failed to submit track to ListenBrainz: {}", err)
+                            if let Some(ref token) = config.listenbrainz_token {
+                                let listen = Listen {
+                                    artist: track.artist(),
+                                    track: track.title(),
+                                    album: track.album(),
+                                };
+                                match listen.single(token) {
+                                    Ok(_) => {
+                                        println!("Track submitted to ListenBrainz successfully");
+                                    }
+                                    Err(err) => {
+                                        eprintln!("Failed to submit track to ListenBrainz: {}", err);
+                                    }
+                                }
                             }
                         }
+                        Ok(FilterResult::Ignored) => {}
+                        Err(err) => eprintln!("{}", err),
                     }
+
                     scrobbled_current_song = true;
                 }
             } else if current_play_time >= length {
@@ -172,55 +163,51 @@ pub fn run(config: Config, scrobbler: Option<Scrobbler>) {
             current_play_time += timer.elapsed();
             timer = Instant::now();
         } else {
-            previous_artist.clear();
-            previous_artist.push_str(artist);
-            previous_title.clear();
-            previous_title.push_str(title);
-            previous_album.clear();
-            previous_album.push_str(album);
-
-            let (filtered_artist, filtered_title, filtered_album) =
-                filter_metadata(&config, artist, title, album)
-                    .unwrap_or_else(|| (artist.to_string(), title.to_string(), album.to_string()));
+            previous_track.clone_from(&current_track);
 
             timer = Instant::now();
             current_play_time = Duration::from_secs(0);
             scrobbled_current_song = false;
 
-            println!("----");
-            println!(
-                "Now playing: {} - {} ({})",
-                filtered_artist, filtered_title, filtered_album
-            );
-
             if config.enable_notifications.unwrap_or(false) {
                 Notification::new()
-                    .summary(&filtered_title)
-                    .body(&format!("{} - {}", filtered_artist, filtered_album))
+                    .summary(&current_track.title())
+                    .body(&format!("{} - {}", current_track.artist(), current_track.album()))
                     .timeout(Timeout::Milliseconds(6000))
                     .show()
                     .unwrap();
             }
 
-            let scrobble = Scrobble::new(&filtered_artist, &filtered_title, &filtered_album);
+            println!("----");
+            println!(
+                "Now playing: {} - {} ({})",
+                current_track.artist(), current_track.title(), current_track.album()
+            );
 
-            if let Some(ref scrobbler) = scrobbler {
-                match scrobbler.now_playing(&scrobble) {
-                    Ok(_) => println!("Status updated on Last.fm successfully"),
-                    Err(err) => eprintln!("Failed to update status on Last.fm: {}", err),
-                }
-            }
+            match filter_metadata(&config, current_track) {
+                Ok(FilterResult::Filtered(track)) | Ok(FilterResult::NotFiltered(track)) => {
+                    if let Some(ref scrobbler) = scrobbler {
+                        let scrobble = Scrobble::new(track.artist(), track.title(), track.album());
+                        match scrobbler.now_playing(&scrobble) {
+                            Ok(_) => println!("Status updated on Last.fm successfully"),
+                            Err(err) => eprintln!("Failed to update status on Last.fm: {}", err),
+                        }
+                    }
 
-            if let Some(ref token) = config.listenbrainz_token {
-                let listen = Listen {
-                    artist: &filtered_artist,
-                    track: &filtered_title,
-                    album: &filtered_album,
-                };
-                match listen.playing_now(token) {
-                    Ok(_) => println!("Status updated on ListenBrainz successfully"),
-                    Err(err) => eprintln!("Failed to update status on ListenBrainz: {}", err),
+                    if let Some(ref token) = config.listenbrainz_token {
+                        let listen = Listen {
+                            artist: track.artist(),
+                            track: track.title(),
+                            album: track.album(),
+                        };
+                        match listen.playing_now(token) {
+                            Ok(_) => println!("Status updated on ListenBrainz successfully"),
+                            Err(err) => eprintln!("Failed to update status on ListenBrainz: {}", err),
+                        }
+                    }
                 }
+                Ok(FilterResult::Ignored) => println!("Track ignored"),
+                Err(err) => eprintln!("Failed to filter metadata: {}", err),
             }
         }
 

--- a/src/track.rs
+++ b/src/track.rs
@@ -8,9 +8,17 @@ pub struct Track {
 }
 
 impl Track {
-    pub fn artist(&self) -> &str { &self.artist }
-    pub fn title(&self) -> &str { &self.title }
-    pub fn album(&self) -> &str { &self.album }
+    pub fn artist(&self) -> &str {
+        &self.artist
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn album(&self) -> &str {
+        &self.album
+    }
 
     pub fn new(artist: &str, title: &str, album: &str) -> Self {
         Self {
@@ -33,7 +41,8 @@ impl Track {
     }
 
     pub fn from_metadata(metadata: &Metadata) -> Self {
-        let artist = metadata.artists()
+        let artist = metadata
+            .artists()
             .as_ref()
             .and_then(|artists| artists.first())
             .map(|&artist| artist)
@@ -44,6 +53,10 @@ impl Track {
 
         let album = metadata.album_name().unwrap_or("").to_owned();
 
-        Self { artist, title, album }
+        Self {
+            artist,
+            title,
+            album,
+        }
     }
 }

--- a/src/track.rs
+++ b/src/track.rs
@@ -1,0 +1,49 @@
+use mpris::Metadata;
+
+#[derive(Debug, Default, PartialEq)]
+pub struct Track {
+    artist: String,
+    title: String,
+    album: String,
+}
+
+impl Track {
+    pub fn artist(&self) -> &str { &self.artist }
+    pub fn title(&self) -> &str { &self.title }
+    pub fn album(&self) -> &str { &self.album }
+
+    pub fn new(artist: &str, title: &str, album: &str) -> Self {
+        Self {
+            artist: artist.to_owned(),
+            title: title.to_owned(),
+            album: album.to_owned(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.artist.clear();
+        self.title.clear();
+        self.album.clear();
+    }
+
+    pub fn clone_from(&mut self, other: &Self) {
+        self.artist.clone_from(&other.artist);
+        self.title.clone_from(&other.title);
+        self.album.clone_from(&other.album);
+    }
+
+    pub fn from_metadata(metadata: &Metadata) -> Self {
+        let artist = metadata.artists()
+            .as_ref()
+            .and_then(|artists| artists.first())
+            .map(|&artist| artist)
+            .unwrap_or("")
+            .to_owned();
+
+        let title = metadata.title().unwrap_or("").to_owned();
+
+        let album = metadata.album_name().unwrap_or("").to_owned();
+
+        Self { artist, title, album }
+    }
+}


### PR DESCRIPTION
Tracks can be ignored by returning nothing from the filter script.

Python example:
```python
import sys

artist, title, album = (l.rstrip() for l in sys.stdin.readlines())

ignored_artists = {'Queen', 'Justin Bieber'}

if artist not in ignored_artists:
    print(artist, title, album, sep='\n')
```

Closes #39.