### PR TITLE
Surpressed plaintext password in last.fm config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,7 @@ dependencies = [
  "listenbrainz",
  "mpris",
  "notify-rust",
+ "rpassword",
  "rustfm-scrobble",
  "serde",
  "tempfile",
@@ -1269,6 +1270,18 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rpassword"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf099a1888612545b683d2661a1940089f6c2e5a8e38979b2159da876bfd956"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.5.8"
 dirs = "4.0.0"
 notify-rust = "4.5.6"
 anyhow = "1.0.55"
+rpassword = "6.0.1"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/service/lastfm.rs
+++ b/src/service/lastfm.rs
@@ -12,14 +12,16 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 use std::fs::{self, Permissions};
 use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
 
 use anyhow::Result;
+use anyhow::Context;
 
 use rustfm_scrobble::Scrobbler;
+
+use rpassword::read_password;
 
 use crate::config::config_dir;
 
@@ -52,9 +54,7 @@ pub fn authenticate(scrobbler: &mut Scrobbler) -> Result<()> {
         print!("Password: ");
         io::stdout().flush()?;
 
-        io::stdin().read_line(&mut input)?;
-        input.pop();
-        let password = input;
+        let password = read_password().context("Failed to read password")?;
 
         let session_response = scrobbler.authenticate_with_password(&username, &password)?;
 


### PR DESCRIPTION
Addresses https://github.com/InputUsername/rescrobbled/issues/68
Tested on Fedora 36.