### PR TITLE
Make track album optional for ListenBrainz submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - Removed notification functionality
   - As an alternative, I recommend [mpris-notifier](https://github.com/l1na-forever/mpris-notifier).
+- Made album name optional when submitting to ListenBrainz
+  - ListenBrainz does not require album names for submissions, so they are now optional.
+  - The Last.fm library used by rescrobbled still requires the album, but this restriction could
+    be lifted in the future.
+  - This does have the side effect of now treating empty album names (eg. "")
+    the same as if they were missing from the MPRIS metadata.
+- Moved to OpenSSL/`libssl` version 3
 
 ## v0.6.2 (2022-11-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "listenbrainz"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40272a10d03d8e48b8d9686d90401199be8d7b70618049a90b79956b2627a43"
+checksum = "f8106205fa554ff3f0a4ac99873f0da320e4e480079bf959476b654bac8e1401"
 dependencies = [
  "attohttpc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 mpris = "2.0.0"
 rustfm-scrobble-proxy = "1.1.3"
-listenbrainz = "0.4.3"
+listenbrainz = "0.5.0"
 serde = { version = "1.0.136", features = ["derive"] }
 toml = "0.5.8"
 dirs = "4.0.0"

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -165,13 +165,15 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
             current_play_time = Duration::from_secs(0);
             scrobbled_current_song = false;
 
-            println!(
+            print!(
                 "----\n\
-                Now playing: {} - {} ({})",
+                Now playing: {} - {}",
                 current_track.artist(),
                 current_track.title(),
-                current_track.album()
             );
+            if let Some(album) = current_track.album() {
+                println!(" ({album})");
+            }
 
             match filter_metadata(&config, current_track, &metadata) {
                 Ok(FilterResult::Filtered(track)) | Ok(FilterResult::NotFiltered(track)) => {

--- a/src/track.rs
+++ b/src/track.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Koen Bolhuis
+// Copyright (C) 2023 Koen Bolhuis
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,13 +15,11 @@
 
 use mpris::Metadata;
 
-use rustfm_scrobble_proxy::Scrobble;
-
 #[derive(Debug, Default, PartialEq)]
 pub struct Track {
     artist: String,
     title: String,
-    album: String,
+    album: Option<String>,
 }
 
 impl Track {
@@ -33,22 +31,28 @@ impl Track {
         &self.title
     }
 
-    pub fn album(&self) -> &str {
-        &self.album
+    pub fn album(&self) -> Option<&str> {
+        self.album.as_deref()
     }
 
-    pub fn new(artist: &str, title: &str, album: &str) -> Self {
+    pub fn new(artist: &str, title: &str, album: Option<&str>) -> Self {
         Self {
             artist: artist.to_owned(),
             title: title.to_owned(),
-            album: album.to_owned(),
+            album: album.and_then(|album| {
+                if !album.is_empty() {
+                    Some(album.to_owned())
+                } else {
+                    None
+                }
+            }),
         }
     }
 
     pub fn clear(&mut self) {
         self.artist.clear();
         self.title.clear();
-        self.album.clear();
+        self.album.take();
     }
 
     pub fn clone_from(&mut self, other: &Self) {
@@ -67,7 +71,14 @@ impl Track {
 
         let title = metadata.title().unwrap_or("").to_owned();
 
-        let album = metadata.album_name().unwrap_or("").to_owned();
+        let album = metadata.album_name().and_then(|album| {
+            if !album.is_empty() {
+                eprintln!("album <{album}> not empty");
+                Some(album.to_owned())
+            } else {
+                None
+            }
+        });
 
         Self {
             artist,
@@ -77,8 +88,85 @@ impl Track {
     }
 }
 
-impl From<&Track> for Scrobble {
-    fn from(track: &Track) -> Scrobble {
-        Scrobble::new(track.artist(), track.title(), track.album())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpris::MetadataValue;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_new() {
+        // Constructing a track with an empty album should result in `None` for `Track::album()`
+
+        assert_eq!(
+            Track::new("Enter Shikari", "Live Outside", None).album(),
+            None
+        );
+
+        // Constructing a track with a nonempty album should result in `Some` for `Track::album()`
+
+        assert_eq!(
+            Track::new("Dimension", "Psycho", Some("Organ")).album(),
+            Some("Organ")
+        );
+    }
+
+    #[test]
+    fn test_from_metadata() {
+        // Metadata without an album should result in a `None` for `Track::album()`
+
+        let mut metadata_without_album = HashMap::new();
+        metadata_without_album.insert(
+            "xesam:artists".to_owned(),
+            MetadataValue::Array(vec![MetadataValue::String("Billy Joel".to_owned())]),
+        );
+        metadata_without_album.insert(
+            "xesam:title".to_owned(),
+            MetadataValue::String("We didn't start the fire".to_owned()),
+        );
+        let metadata_without_album = Metadata::from(metadata_without_album);
+        let track_without_album = Track::from_metadata(&metadata_without_album);
+
+        assert_eq!(track_without_album.album(), None);
+
+        // Metadata with an empty album should result in a `None` for `Track::album()`
+
+        let mut metadata_empty_album = HashMap::new();
+        metadata_empty_album.insert(
+            "xesam:artist".to_owned(),
+            MetadataValue::Array(vec![MetadataValue::String("The Prodigy".to_owned())]),
+        );
+        metadata_empty_album.insert(
+            "xesam:title".to_owned(),
+            MetadataValue::String("Wild Frontier".to_owned()),
+        );
+        metadata_empty_album.insert(
+            "xesam:album".to_owned(),
+            MetadataValue::String("".to_owned()),
+        );
+        let metadata_empty_album = Metadata::from(metadata_empty_album);
+        let track_empty_album = Track::from_metadata(&metadata_empty_album);
+
+        assert_eq!(track_empty_album.album(), None);
+
+        // Metadata with a nonempty album should result in a `Some` for `Track::album()`
+
+        let mut metadata_with_album = HashMap::new();
+        metadata_with_album.insert(
+            "xesam:artist".to_owned(),
+            MetadataValue::Array(vec![MetadataValue::String("Men At Work".to_owned())]),
+        );
+        metadata_with_album.insert(
+            "xesam:title".to_owned(),
+            MetadataValue::String("Who Can It Be Now?".to_owned()),
+        );
+        metadata_with_album.insert(
+            "xesam:album".to_owned(),
+            MetadataValue::String("Business As Usual".to_owned()),
+        );
+        let metadata_with_album = Metadata::from(metadata_with_album);
+        let track_with_album = Track::from_metadata(&metadata_with_album);
+
+        assert_eq!(track_with_album.album(), Some("Business As Usual"));
     }
 }

--- a/src/track.rs
+++ b/src/track.rs
@@ -73,7 +73,6 @@ impl Track {
 
         let album = metadata.album_name().and_then(|album| {
             if !album.is_empty() {
-                eprintln!("album <{album}> not empty");
                 Some(album.to_owned())
             } else {
                 None


### PR DESCRIPTION
- ListenBrainz does not require album names for submissions, so they are now optional.
- rustfm-scrobble(-proxy) still requires the album, but this restriction could be lifted in the future.
- This does have the side effect of now treating empty album names (eg. "") the same as if they were missing from the MPRIS metadata.