### PR TITLE
Update player finding logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     be lifted in the future.
   - This does have the side effect of now treating empty album names (eg. "")
     the same as if they were missing from the MPRIS metadata.
+- Updated player finding logic to be more resilient to players that cause errors
 - Moved to OpenSSL/`libssl` version 3
 
 ## v0.6.2 (2022-11-16)

--- a/src/player.rs
+++ b/src/player.rs
@@ -68,7 +68,7 @@ fn is_whitelisted(config: &Config, player: &Player) -> bool {
 /// Wait for any (whitelisted) player to become active again.
 pub fn wait_for_player(config: &Config, finder: &PlayerFinder) -> Player {
     loop {
-        let players = match finder.find_all() {
+        let players = match finder.iter_players() {
             Ok(players) => players,
             _ => {
                 thread::sleep(INIT_WAIT_TIME);
@@ -77,8 +77,10 @@ pub fn wait_for_player(config: &Config, finder: &PlayerFinder) -> Player {
         };
 
         for player in players {
-            if is_active(&player) && is_whitelisted(config, &player) {
-                return player;
+            if let Ok(player) = player {
+                if is_active(&player) && is_whitelisted(config, &player) {
+                    return player;
+                }
             }
         }
 


### PR DESCRIPTION
Update player finding logic to be more resilient to players that cause errors.

`PlayerFinder::find_all` just errors out whenever any player causes an error. `wait_for_player` now uses `PlayerFinder::iter_players` instead, ignoring errored players.