### PR TITLE
Scrobble with original timestamp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ toml = "0.8.20"
 dirs = "5.0.1"
 anyhow = "1.0.97"
 rpassword = "7.3.1"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ toml = "0.8.22"
 dirs = "6.0.0"
 anyhow = "1.0.98"
 rpassword = "7.4.0"
-chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -59,7 +59,7 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
     let mut timer = Instant::now();
     let mut current_play_time = Duration::from_secs(0);
     let mut scrobbled_current_song = false;
-    let mut track_start_unix: i64 = 0;
+    let mut track_start = SystemTime::now();
 
     loop {
         if !player::is_active(&player) {

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -25,8 +25,6 @@ use crate::filter::{filter_metadata, FilterResult};
 use crate::player;
 use crate::service::Service;
 use crate::track::Track;
-
-use chrono::Utc;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -151,7 +151,7 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
             {
                 current_play_time = Duration::from_secs(0);
                 scrobbled_current_song = false;
-                track_start_unix = Utc::now().timestamp();
+                track_start = SystemTime::now();
             }
 
             current_play_time += timer.elapsed();

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -131,7 +131,7 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
                         Ok(FilterResult::Filtered(track))
                         | Ok(FilterResult::NotFiltered(track)) => {
                             for service in services.iter() {
-                                match service.submit(&track, track_start_unix) {
+                                match service.submit(&track, &track_start) {
                                     Ok(()) => {
                                         println!("Track submitted to {} successfully", service)
                                     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -123,10 +123,12 @@ impl Service {
     }
 
     /// Scrobble a track.
-    pub fn submit(&self, track: &Track) -> Result<()> {
+    pub fn submit(&self, track: &Track, timestamp: i64) -> Result<()> {
         match self {
             Self::LastFM(scrobbler) => {
-                let scrobble = Scrobble::new(track.artist(), track.title(), track.album());
+                let mut scrobble = Scrobble::new(track.artist(),track.title(),track.album());
+
+                scrobble.with_timestamp(timestamp.try_into().unwrap());
 
                 scrobbler
                     .scrobble(&scrobble)

--- a/src/service.rs
+++ b/src/service.rs
@@ -128,7 +128,8 @@ impl Service {
             Self::LastFM(scrobbler) => {
                 let mut scrobble = Scrobble::new(track.artist(),track.title(),track.album());
 
-                scrobble.with_timestamp(timestamp.try_into().unwrap());
+                let timestamp = track_start.duration_since(UNIX_EPOCH); // might need to handle the error here
+                scrobble.with_timestamp(timestamp.as_secs());
 
                 scrobbler
                     .scrobble(&scrobble)

--- a/src/service.rs
+++ b/src/service.rs
@@ -123,7 +123,7 @@ impl Service {
     }
 
     /// Scrobble a track.
-    pub fn submit(&self, track: &Track, timestamp: i64) -> Result<()> {
+    pub fn submit(&self, track: &Track, track_start: &SystemTime) -> Result<()> {
         match self {
             Self::LastFM(scrobbler) => {
                 let mut scrobble = Scrobble::new(track.artist(),track.title(),track.album());

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::fmt::{self, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -126,9 +127,12 @@ impl Service {
     pub fn submit(&self, track: &Track, track_start: &SystemTime) -> Result<()> {
         match self {
             Self::LastFM(scrobbler) => {
-                let mut scrobble = Scrobble::new(track.artist(),track.title(),track.album());
+                let mut scrobble = Scrobble::new(track.artist(), track.title(), track.album());
 
-                let timestamp = track_start.duration_since(UNIX_EPOCH); // might need to handle the error here
+                let timestamp = track_start
+                    .duration_since(UNIX_EPOCH)
+                    .context("Track started before UNIX epoch")?;
+
                 scrobble.with_timestamp(timestamp.as_secs());
 
                 scrobbler


### PR DESCRIPTION
This PR updates the scrobbling behavior to use the track’s playback start timestamp (from the now playing event) when sending the final scrobble to Last.fm. Previously, the scrobble used the current time when the 50% or minimum duration threshold was reached.