### PR TITLE
Use shellexpand in secret file resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           awk "/^## $GITHUB_REF_NAME/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md >changes.txt
       - name: Create release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           body_path: changes.txt
           files: target/release/rescrobbled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
       - name: Install dependencies
         run: sudo apt-get install --no-install-recommends -y libdbus-1-dev dbus
-      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
       - name: Release on crates.io
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "rpassword",
  "rustfm-scrobble-proxy",
  "serde",
+ "shellexpand",
  "tempfile",
  "toml",
 ]
@@ -903,6 +904,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ toml = "1.0.2"
 dirs = "6.0.0"
 anyhow = "1.0.102"
 rpassword = "7.4.0"
+shellexpand = "3.1.2"
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, fs, path::PathBuf};
+use std::{borrow::Cow, fs, path::PathBuf, str::FromStr};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -88,13 +88,7 @@ macro_rules! impl_secret {
                 match self {
                     $name::Inline(secret) => Ok(Cow::Borrowed(secret)),
                     $name::File(path) => {
-                        let path = if let Some(stripped) = path.strip_prefix("~/") {
-                            dirs::home_dir()
-                                .ok_or_else(|| anyhow!("User home directory does not exist"))?
-                                .join(stripped)
-                        } else {
-                            PathBuf::from(path)
-                        };
+                        let path = PathBuf::from_str(&(shellexpand::full(&path)?))?;
                         let secret = fs::read_to_string(path)?;
 
                         Ok(Cow::Owned(secret.trim().to_owned()))


### PR DESCRIPTION
Expands environment variables and `~` in secret file paths.

This is usefull because agenix in home-manager creates paths that reference `XDG_RUNTIME_DIR`.