### PR TITLE
Add album artist support and improve scrobbling logic (Claude Code generated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- Fixed when a track counts as a scrobble
+  - A track is only scrobbled if it is longer than 30 seconds and has been played for at least half
+    its duration, or for 4 minutes, whichever occurs earlier
+  - Time spent paused no longer counts as play time, and no longer discards the play time a track
+    had built up: pausing and resuming continues where the track left off instead of starting it over
+  - Tracks whose player does not report a length are scrobbled after 4 minutes of play, instead of
+    after 15 seconds
+- Changed Last.fm submission to happen when a track has finished playing
+  - The "now playing" status is refreshed while the track keeps playing, so it shows for the whole
+    track instead of expiring partway through
+  - The scrobble is submitted once the track has finished (because it ended, was skipped, or its
+    player was stopped or quit), timestamped with the time and date the track started playing
+  - The track length is submitted along with scrobbles and status updates
+  - ListenBrainz is unaffected: listens are still submitted as soon as a track has been played long
+    enough, and are recorded at the time of submission
+- Removed the `use-track-start-timestamp` option (and its `USE_TRACK_START_TIMESTAMP` environment
+  variable), which is now what Last.fm scrobbles always do
+- A player that is paused no longer counts as stopped: rescrobbled sticks with it until it is
+  resumed, another player starts playing, or the player stops or quits
 - Fixed the album artist not being scrobbled
   - Previously Last.fm assumed the album artist equalled the track artist, which split compilations,
     DJ mixes and other various-artists releases into a separate album per track artist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the album artist not being scrobbled
+  - Previously Last.fm assumed the album artist equalled the track artist, which split compilations,
+    DJ mixes and other various-artists releases into a separate album per track artist
+  - The album artist is read from the player's `xesam:albumArtist` metadata and submitted to Last.fm
+    as `albumArtist` when it differs from the track artist
+  - ListenBrainz is unchanged, as its listen submission API has no album artist field
+- Added the album artist to the filter script interface
+  - It is passed as a fifth input line, after the genres
+  - Scripts can write it as a fourth output line; if that line is missing or empty, the album artist
+    reported by the player is used unchanged
+  - **Note:** filter scripts that read *all* of their standard input and expect exactly four lines
+    (like the bundled Python examples used to) need updating for the extra input line
+- Last.fm scrobbles and status updates are now submitted directly instead of through
+  `rustfm-scrobble-proxy`, which cannot send the `albumArtist` parameter (the crate is still used to
+  log in)
+
 ## v0.10.0 (2026-06-18)
 
 - Added shell expansion (e.g. environment variables, `~`) to secret file resolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@
     its duration, or for 4 minutes, whichever occurs earlier
   - Time spent paused no longer counts as play time, and no longer discards the play time a track
     had built up: pausing and resuming continues where the track left off instead of starting it over
-  - Tracks whose player does not report a length are scrobbled after 4 minutes of play, instead of
+  - Tracks whose player does not report a length only count after 4 minutes of play, instead of
     after 15 seconds
-- Changed Last.fm submission to happen when a track has finished playing
-  - The "now playing" status is refreshed while the track keeps playing, so it shows for the whole
-    track instead of expiring partway through
-  - The scrobble is submitted once the track has finished (because it ended, was skipped, or its
-    player was stopped or quit), timestamped with the time and date the track started playing
-  - The track length is submitted along with scrobbles and status updates
-  - ListenBrainz is unaffected: listens are still submitted as soon as a track has been played long
-    enough, and are recorded at the time of submission
+- Changed submission to happen when a track is done playing, instead of partway through it
+  - The play time rules decide whether a track counts as a scrobble, not when it is submitted:
+    scrobbles now go out the moment a track has played all the way through, or, when its play ends
+    early because it was skipped or its player was stopped or quit, at that point
+  - A track shows as "now playing" for as long as it plays; on Last.fm the status is refreshed while
+    it keeps playing, instead of expiring partway through
+  - Last.fm scrobbles are timestamped with the time and date the track started playing; ListenBrainz
+    listens are still recorded at the time they are submitted, as its API takes no timestamp
+  - The track length is submitted along with Last.fm scrobbles and status updates
 - Removed the `use-track-start-timestamp` option (and its `USE_TRACK_START_TIMESTAMP` environment
   variable), which is now what Last.fm scrobbles always do
 - A player that is paused no longer counts as stopped: rescrobbled sticks with it until it is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,13 +682,16 @@ name = "rescrobbled"
 version = "0.10.0"
 dependencies = [
  "anyhow",
+ "attohttpc 0.30.1",
  "dirs",
  "listenbrainz",
+ "md5",
  "mpris",
  "regex",
  "rpassword",
  "rustfm-scrobble-proxy",
  "serde",
+ "serde_json",
  "shellexpand",
  "tempfile",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ anyhow = "1.0.102"
 rpassword = "7.5.4"
 shellexpand = "3.1.2"
 regex = "1.12.3"
+attohttpc = { version = "0.30", features = ["form"] }
+md5 = "0.8"
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If the config file doesn't exist, rescrobbled will generate an example config fo
         <td><code>min-play-time</code></td>
         <td>
             <p>Minimum play time in seconds before a song is scrobbled.</p>
-            <p>By default, track submission respects Last.fm's recommended behavior: songs are only scrobbled if they are longer than 30 seconds and have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using <code>min-play-time</code> you can override the play time that is required; songs of 30 seconds or shorter are never scrobbled.</p>
+            <p>By default, track submission respects Last.fm's recommended behavior: songs only count as a scrobble if they are longer than 30 seconds and have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using <code>min-play-time</code> you can override the play time that is required; songs of 30 seconds or shorter are never scrobbled.</p>
             <p>Time spent paused does not count towards the play time.</p>
         </td>
     </tr>
@@ -144,17 +144,19 @@ systemctl --user start rescrobbled.service
 
 ### When a track is scrobbled
 
-A track is a scrobble when it is longer than 30 seconds and has been played for at least half its
-duration, or for 4 minutes, whichever occurs earlier. Time spent paused does not count towards the
-play time, and a paused track picks up where it left off when playback resumes.
+Scrobbles are submitted when a track is done playing: the moment it has played all the way
+through, or, if its play ends early because it was skipped or its player was stopped or quit, at
+that point. While a track is playing it shows as "now playing" instead; on Last.fm the status is
+refreshed for as long as the track keeps playing.
 
-Last.fm is kept up to date for the whole time a track plays: the "now playing" status is refreshed
-while it keeps playing, and the scrobble is submitted once the track has finished playing (because
-it ended, was skipped, or its player was stopped or quit), timestamped with the time and date the
-track started playing.
+Whether a finished track counts as a scrobble at all is a separate question: it has to be longer
+than 30 seconds and have been played for at least half its duration, or for 4 minutes, whichever
+occurs earlier. Time spent paused does not count towards the play time, and a paused track picks up
+where it left off when playback resumes.
 
-ListenBrainz listens are submitted as soon as the track has been played long enough, and are
-recorded at the time of submission, because the listen submission API takes no timestamp.
+Last.fm scrobbles are timestamped with the time and date the track started playing. ListenBrainz
+listens are recorded at the time they are submitted, because the listen submission API takes no
+timestamp.
 
 ## Project resources
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,15 @@ If the config file doesn't exist, rescrobbled will generate an example config fo
                 <li>artist;</li>
                 <li>song title;</li>
                 <li>album name;</li>
-                <li>zero or more comma-separated (<code>,</code>) genre(s)</li>
+                <li>zero or more comma-separated (<code>,</code>) genre(s);</li>
+                <li>album artist</li>
             </ul>
             </p>
-            <p>The script should write the filtered artist, song title and album name on corresponding lines of its standard output.
+            <p>The script should write the filtered artist, song title, album name and album artist on corresponding lines of its standard output.
             This can be used to clean up song names, for example removing "remastered" and similar suffixes.
-            If the filter script does not return any output, the current track will be ignored.</p>
+            If the filter script does not return any output, the current track will be ignored.
+            The album artist line is optional; if it is missing or empty, the album artist reported by the player is used unchanged,
+            so scripts written before this line existed keep working.</p>
             <p>A number of example scripts can be found in the <a href="https://github.com/InputUsername/rescrobbled/tree/master/filter-script-examples"><code>filter-script-examples</code></a> directory.</p>
         </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ min-play-time = 0
 player-whitelist = [ "Player MPRIS identity or bus name", "regex.*" ]
 player-ignorelist = [ "name", "regex.*" ]
 filter-script = "path/to/script"
-use-track-start-timestamp = false
 
 [[listenbrainz]]
 url = "Custom API URL"
@@ -60,7 +59,8 @@ If the config file doesn't exist, rescrobbled will generate an example config fo
         <td><code>min-play-time</code></td>
         <td>
             <p>Minimum play time in seconds before a song is scrobbled.</p>
-            <p>By default, track submission respects Last.fm's recommended behavior: songs should only be scrobbled if they have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using <code>min-play-time</code> you can override this.</p>
+            <p>By default, track submission respects Last.fm's recommended behavior: songs are only scrobbled if they are longer than 30 seconds and have been playing for at least half their duration, or for 4 minutes, whichever comes first. Using <code>min-play-time</code> you can override the play time that is required; songs of 30 seconds or shorter are never scrobbled.</p>
+            <p>Time spent paused does not count towards the play time.</p>
         </td>
     </tr>
     <tr>
@@ -96,10 +96,6 @@ If the config file doesn't exist, rescrobbled will generate an example config fo
         </td>
     </tr>
     <tr>
-        <td><code>use-track-start-timestamp</code></td>
-        <td>By default, tracks are submitted with a timestamp of the submission time. By setting <code>use-track-start-timestamp</code> to <code>true</code>, tracks are instead submitted with the time the track originally started playing. This is currently Last.fm-only.</td>
-    </tr>
-    <tr>
         <td><code>[[listenbrainz]]</code></td>
         <td>
             <p>You can specify one or more ListenBrainz instances by repeating this option. Each definition needs at least a <code>token</code>. You can set <code>url</code> to use a custom API URL (eg. for use with custom ListenBrainz instances or services like <a href="https://github.com/krateng/maloja">Maloja</a>). If the URL is not provided, it defaults to the ListenBrainz.org instance.</p>
@@ -122,7 +118,6 @@ Some options can be set using environment variables. The following options are s
 | `listenbrainz-token` | `LISTENBRAINZ_TOKEN` |
 | `min-play-time` | `MIN_PLAY_TIME` |
 | `filter-script` | `FILTER_SCRIPT` |
-| `use-track-start-timestamp` | `USE_TRACK_START_TIMESTAMP` |
 
 ### Loading secrets from files
 
@@ -146,6 +141,20 @@ You can run it in the current session using:
 ```
 systemctl --user start rescrobbled.service
 ```
+
+### When a track is scrobbled
+
+A track is a scrobble when it is longer than 30 seconds and has been played for at least half its
+duration, or for 4 minutes, whichever occurs earlier. Time spent paused does not count towards the
+play time, and a paused track picks up where it left off when playback resumes.
+
+Last.fm is kept up to date for the whole time a track plays: the "now playing" status is refreshed
+while it keeps playing, and the scrobble is submitted once the track has finished playing (because
+it ended, was skipped, or its player was stopped or quit), timestamped with the time and date the
+track started playing.
+
+ListenBrainz listens are submitted as soon as the track has been played long enough, and are
+recorded at the time of submission, because the listen submission API takes no timestamp.
 
 ## Project resources
 

--- a/filter-script-examples/basic.py
+++ b/filter-script-examples/basic.py
@@ -2,13 +2,13 @@
 
 import sys
 
-# Filter scripts receive the track artist, title, album and comma-separated list of genre(s)
-# on separate lines of their standard input...
+# Filter scripts receive the track artist, title, album, comma-separated list of genre(s)
+# and album artist on separate lines of their standard input...
 
-artist, title, album, genres = (l.rstrip() for l in sys.stdin.readlines())
+artist, title, album, genres, album_artist = (l.rstrip() for l in sys.stdin.readlines())
 genres = genres.split(',')
 
-# ...and should provide artist, title and album on the corresponding lines of the
-# standard output
+# ...and should provide artist, title, album and album artist on the corresponding lines
+# of the standard output
 
-print(artist, title, album, sep='\n')
+print(artist, title, album, album_artist, sep='\n')

--- a/filter-script-examples/ignore_artists.py
+++ b/filter-script-examples/ignore_artists.py
@@ -2,11 +2,11 @@
 
 import sys
 
-artist, title, album, _ = (l.rstrip() for l in sys.stdin.readlines())
+artist, title, album, _, album_artist = (l.rstrip() for l in sys.stdin.readlines())
 
 # Ignore all tracks by specific artists
 
 IGNORED_ARTISTS = {'Justin Bieber', 'The Beatles', 'Michael Jackson'}
 
 if artist not in IGNORED_ARTISTS:
-    print(artist, title, album, sep='\n')
+    print(artist, title, album, album_artist, sep='\n')

--- a/filter-script-examples/ignore_genre.py
+++ b/filter-script-examples/ignore_genre.py
@@ -2,11 +2,11 @@
 
 import sys
 
-artist, title, album, genres = (l.rstrip() for l in sys.stdin.readlines())
+artist, title, album, genres, album_artist = (l.rstrip() for l in sys.stdin.readlines())
 genres = genres.lower().split(',')
 
 IGNORED_GENRES = {'country', 'idm'}
 
 # Only output if none of the genres are in the IGNORED_GENRES
 if all(genre not in IGNORED_GENRES for genre in genres):
-    print(artist, title, album, sep='\n')
+    print(artist, title, album, album_artist, sep='\n')

--- a/filter-script-examples/parse_artist_from_title.py
+++ b/filter-script-examples/parse_artist_from_title.py
@@ -2,11 +2,11 @@
 
 import sys
 
-artist, title, album, _ = (l.rstrip() for l in sys.stdin.readlines())
+artist, title, album, _, album_artist = (l.rstrip() for l in sys.stdin.readlines())
 
 # Parse the artist from the track title if the artist is empty
 
 if len(artist) == 0:
     artist, title = title.split(' - ', maxsplit=1)
 
-print(artist, title, album, sep='\n')
+print(artist, title, album, album_artist, sep='\n')

--- a/filter-script-examples/shell_example.sh
+++ b/filter-script-examples/shell_example.sh
@@ -3,7 +3,10 @@
 read artist
 read title
 read album
+read genres
+read album_artist
 
 echo "Artist=$artist"
 echo "Title=$title"
 echo "Album=$album"
+echo "AlbumArtist=$album_artist"

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,7 +105,6 @@ pub struct Config {
     )]
     pub player_ignorelist: Option<RegexSet>,
     pub filter_script: Option<PathBuf>,
-    pub use_track_start_timestamp: Option<bool>,
     pub listenbrainz: Option<Vec<ListenBrainzConfig>>,
 }
 
@@ -119,7 +118,6 @@ impl Config {
             player_whitelist: Some(RegexSet::default()),
             player_ignorelist: Some(RegexSet::default()),
             filter_script: Some(PathBuf::new()),
-            use_track_start_timestamp: Some(false),
             listenbrainz: Some(vec![ListenBrainzConfig {
                 url: Some(String::new()),
                 token: ListenBrainzToken::default(),
@@ -200,10 +198,6 @@ fn override_from_environment(config: &mut Config) -> Result<()> {
         get_envvar::<u64>("MIN_PLAY_TIME").map(|t| t.map(Duration::from_secs))?,
     );
     replace_if_some(&mut config.filter_script, get_envvar("FILTER_SCRIPT")?);
-    replace_if_some(
-        &mut config.use_track_start_timestamp,
-        get_envvar("USE_TRACK_START_TIMESTAMP")?,
-    );
 
     Ok(())
 }
@@ -296,7 +290,6 @@ mod tests {
             std::env::set_var("LISTENBRAINZ_TOKEN", "listenbrainz_token_xyz");
             std::env::set_var("MIN_PLAY_TIME", "30");
             std::env::set_var("FILTER_SCRIPT", "/tmp/filter.sh");
-            std::env::set_var("USE_TRACK_START_TIMESTAMP", "true");
         }
 
         override_from_environment(&mut config).unwrap();
@@ -320,7 +313,6 @@ mod tests {
             config.filter_script.as_deref(),
             Some(Path::new("/tmp/filter.sh"))
         );
-        assert_eq!(config.use_track_start_timestamp, Some(true));
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -56,12 +56,15 @@ pub fn filter_metadata(config: &Config, track: Track, metadata: &Metadata) -> Re
         .and_then(|value| value.as_str_array())
         .unwrap_or_default();
 
+    // The album artist is appended after the genre to keep the order of the
+    // preceding lines stable for existing filter scripts
     let buffer = format!(
-        "{}\n{}\n{}\n{}\n",
+        "{}\n{}\n{}\n{}\n{}\n",
         track.artist(),
         track.title(),
         track.album().unwrap_or(""),
         genre.join(","),
+        track.album_artist().unwrap_or(""),
     );
     stdin
         .write_all(buffer.as_bytes())
@@ -94,9 +97,17 @@ pub fn filter_metadata(config: &Config, track: Track, metadata: &Metadata) -> Re
         String::from_utf8(output.stdout).context("Filter script stdout is not valid UTF-8")?;
 
     let mut output = output.split('\n');
-    match (output.next(), output.next(), output.next()) {
-        (Some(artist), Some(title), album) => {
-            Ok(FilterResult::Filtered(Track::new(artist, title, album)))
+    match (output.next(), output.next(), output.next(), output.next()) {
+        (Some(artist), Some(title), album, album_artist) => {
+            // Scripts written before the album artist line existed leave it
+            // blank, so fall back to the album artist reported by the player
+            let album_artist = album_artist
+                .filter(|album_artist| !album_artist.is_empty())
+                .or_else(|| track.album_artist());
+
+            Ok(FilterResult::Filtered(
+                Track::new(artist, title, album).with_album_artist(album_artist),
+            ))
         }
         _ => Ok(FilterResult::Ignored),
     }
@@ -208,6 +219,44 @@ echo \"$album\"
             )
             .unwrap(),
             FilterResult::Filtered(Track::new("lorem", "ipsum", None)),
+        );
+
+        // A script that omits the album artist should leave the original one intact
+
+        let track = Track::new("lorem", "ipsum", None).with_album_artist(Some("sit"));
+        let expected = Track::new("lorem", "ipsum", None).with_album_artist(Some("sit"));
+
+        assert_eq!(
+            filter_metadata(&config, track, &Metadata::new("track_id")).unwrap(),
+            FilterResult::Filtered(expected),
+        );
+
+        // A script should be able to read and write the album artist
+
+        let path_album_artist = temp_dir.path().join("filter_album_artist.sh");
+        const FILTER_SCRIPT_ALBUM_ARTIST: &str = "#!/usr/bin/env sh
+read artist
+read title
+read album
+read genre
+read album_artist
+echo \"$artist\"
+echo \"$title\"
+echo \"$album\"
+echo \"AlbumArtist=$album_artist\"
+";
+
+        write_test_script(&path_album_artist, FILTER_SCRIPT_ALBUM_ARTIST);
+
+        config.filter_script = Some(path_album_artist);
+
+        let track = Track::new("lorem", "ipsum", Some("dolor")).with_album_artist(Some("sit"));
+        let expected =
+            Track::new("lorem", "ipsum", Some("dolor")).with_album_artist(Some("AlbumArtist=sit"));
+
+        assert_eq!(
+            filter_metadata(&config, track, &Metadata::new("track_id")).unwrap(),
+            FilterResult::Filtered(expected),
         )
     }
 }

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -58,8 +58,7 @@ struct Playing {
     timer: Instant,
     /// When the "now playing" status was last updated.
     status_updated: Instant,
-    /// Whether the services that scrobble as soon as a track has been played
-    /// long enough have received it.
+    /// Whether the track has been scrobbled already.
     submitted: bool,
 }
 
@@ -73,6 +72,17 @@ impl Playing {
     /// Skip the time since the previous poll, which was spent paused.
     fn hold(&mut self) {
         self.timer = Instant::now();
+    }
+
+    /// Whether the track played all the way through.
+    ///
+    /// The play time lags the position by up to one poll, so a track within a
+    /// poll of its length counts as having played completely. That keeps the
+    /// last track of a queue from going unscrobbled when its player pauses on
+    /// the final moment instead of moving on.
+    fn played_completely(&self) -> bool {
+        self.length
+            .is_some_and(|length| self.play_time + POLL_INTERVAL >= length)
     }
 
     /// Whether the track played past its length, so it must have started over.
@@ -189,9 +199,13 @@ fn refresh_now_playing(services: &[Service], playing: &mut Playing) {
     }
 }
 
-/// Submit a track to the services that scrobble it as soon as it has been
-/// played long enough.
-fn submit_when_played(config: &Config, services: &[Service], playing: &mut Playing) {
+/// Scrobble a track whose play has come to an end, timestamped with the time
+/// and date it started playing.
+///
+/// This is where every scrobble is submitted: a track that played completely is
+/// submitted the moment it did, and one whose play ended early when it is done
+/// playing. Whether it counts as a scrobble at all is up to [`should_scrobble`].
+fn submit_track(config: &Config, services: &[Service], playing: &mut Playing) {
     if playing.submitted || !should_scrobble(config, playing.length, playing.play_time) {
         return;
     }
@@ -202,32 +216,7 @@ fn submit_when_played(config: &Config, services: &[Service], playing: &mut Playi
         return;
     };
 
-    for service in services
-        .iter()
-        .filter(|service| !service.scrobbles_at_track_end())
-    {
-        match service.submit(track, playing.start, playing.length) {
-            Ok(()) => println!("Track submitted to {} successfully", service),
-            Err(err) => eprintln!("{:?}", err),
-        }
-    }
-}
-
-/// Submit a track that has finished playing to the services that wait for it,
-/// timestamped with the time and date the track started playing.
-fn finish_track(config: &Config, services: &[Service], playing: Playing) {
-    if !should_scrobble(config, playing.length, playing.play_time) {
-        return;
-    }
-
-    let Some(track) = playing.submission.as_ref() else {
-        return;
-    };
-
-    for service in services
-        .iter()
-        .filter(|service| service.scrobbles_at_track_end())
-    {
+    for service in services.iter() {
         match service.submit(track, playing.start, playing.length) {
             Ok(()) => println!("Track submitted to {} successfully", service),
             Err(err) => eprintln!("{:?}", err),
@@ -250,9 +239,9 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
 
     loop {
         if !player.is_running() {
-            // The track cannot be resumed, so it ends here
-            if let Some(track) = playing.take() {
-                finish_track(&config, &services, track);
+            // The track cannot be resumed, so its play ends here
+            if let Some(mut track) = playing.take() {
+                submit_track(&config, &services, &mut track);
             }
 
             println!(
@@ -290,8 +279,8 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
                 .filter(|other| other.bus_name() != player.bus_name());
 
             if status == PlaybackStatus::Stopped || takeover.is_some() {
-                if let Some(track) = playing.take() {
-                    finish_track(&config, &services, track);
+                if let Some(mut track) = playing.take() {
+                    submit_track(&config, &services, &mut track);
                 }
             } else if let Some(track) = playing.as_mut() {
                 track.hold();
@@ -336,21 +325,29 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
             Some(track) if track.track != current_track => true,
             Some(track) => {
                 track.tick();
-                // The track played all the way through and started over
+
+                // A track that has played completely is a scrobble there and
+                // then, however long the player stays on it
+                if track.played_completely() {
+                    submit_track(&config, &services, track);
+                }
+
+                // The track played past its length, so it started over
                 track.started_over()
             }
             None => false,
         };
 
-        if ended && let Some(track) = playing.take() {
-            finish_track(&config, &services, track);
+        // The play ended before the track was over; it is still a scrobble if
+        // it was played long enough
+        if ended && let Some(mut track) = playing.take() {
+            submit_track(&config, &services, &mut track);
         }
 
         let playing = playing.get_or_insert_with(|| {
             start_track(&config, &services, current_track, &metadata, length)
         });
 
-        submit_when_played(&config, &services, playing);
         refresh_now_playing(&services, playing);
 
         thread::sleep(POLL_INTERVAL);
@@ -362,6 +359,53 @@ mod tests {
     use super::*;
 
     const SECOND: Duration = Duration::from_secs(1);
+
+    fn playing(length: Option<Duration>, play_time: Duration) -> Playing {
+        let now = Instant::now();
+
+        Playing {
+            track: Track::default(),
+            submission: None,
+            length,
+            start: SystemTime::now(),
+            play_time,
+            timer: now,
+            status_updated: now,
+            submitted: false,
+        }
+    }
+
+    #[test]
+    fn test_played_completely() {
+        let length = Duration::from_secs(3 * 60);
+
+        // A track counts as played completely once its play time is within a
+        // poll of its length, so that a player pausing on the last moment of a
+        // track does not leave it unscrobbled
+
+        assert!(!playing(Some(length), length / 2).played_completely());
+        assert!(!playing(Some(length), length - POLL_INTERVAL - SECOND).played_completely());
+        assert!(playing(Some(length), length - POLL_INTERVAL).played_completely());
+        assert!(playing(Some(length), length).played_completely());
+
+        // A track without a length never does, however long it plays
+
+        assert!(!playing(None, Duration::from_secs(60 * 60)).played_completely());
+    }
+
+    #[test]
+    fn test_started_over() {
+        let length = Duration::from_secs(3 * 60);
+
+        // A track that played out is not taken for a repeat right away, only
+        // once it keeps playing well past its length
+
+        assert!(!playing(Some(length), length).started_over());
+        assert!(!playing(Some(length), length + RESTART_GRACE - SECOND).started_over());
+        assert!(playing(Some(length), length + RESTART_GRACE).started_over());
+
+        assert!(!playing(None, Duration::from_secs(60 * 60)).started_over());
+    }
 
     #[test]
     fn test_should_scrobble_short_track() {

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -174,7 +174,11 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
                 current_track.title(),
             );
             if let Some(album) = current_track.album() {
-                println!(" ({album})");
+                print!(" ({album}");
+                if let Some(album_artist) = current_track.album_artist() {
+                    print!(" by {album_artist}");
+                }
+                println!(")");
             }
 
             match filter_metadata(&config, current_track, &metadata) {

--- a/src/mainloop.rs
+++ b/src/mainloop.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{Context, Result, anyhow};
 
-use mpris::{PlaybackStatus, PlayerFinder};
+use mpris::{Metadata, PlaybackStatus, PlayerFinder};
 
 use crate::config::Config;
 use crate::filter::{FilterResult, filter_metadata};
@@ -28,17 +28,211 @@ use crate::track::Track;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Tracks up to this length are never scrobbled.
 const MIN_LENGTH: Duration = Duration::from_secs(30);
-const MIN_PLAY_TIME: Duration = Duration::from_secs(4 * 60);
 
-fn get_min_play_time(config: &Config, track_length: Duration) -> Duration {
-    config.min_play_time.unwrap_or_else(|| {
-        if (track_length / 2) < MIN_PLAY_TIME {
-            track_length / 2
-        } else {
-            MIN_PLAY_TIME
+/// A track has been played enough after half its length or this, whichever
+/// comes first.
+const MAX_PLAY_TIME: Duration = Duration::from_secs(4 * 60);
+
+/// How often the "now playing" status is renewed while a track keeps playing.
+const NOW_PLAYING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How far a track is allowed to play past its length before it counts as
+/// having started over.
+const RESTART_GRACE: Duration = Duration::from_secs(5);
+
+/// The track playing on the active player, and how much of it has been played.
+struct Playing {
+    /// The track as reported by the player, used to notice when it changes.
+    track: Track,
+    /// The filtered track that gets submitted, or `None` if it is ignored.
+    submission: Option<Track>,
+    /// The length of the track, if the player reports one.
+    length: Option<Duration>,
+    /// The time and date the track started playing.
+    start: SystemTime,
+    /// How long the track has played, not counting time spent paused.
+    play_time: Duration,
+    /// Start of the stretch of playback not yet counted towards `play_time`.
+    timer: Instant,
+    /// When the "now playing" status was last updated.
+    status_updated: Instant,
+    /// Whether the services that scrobble as soon as a track has been played
+    /// long enough have received it.
+    submitted: bool,
+}
+
+impl Playing {
+    /// Count the time since the previous poll as play time.
+    fn tick(&mut self) {
+        self.play_time += self.timer.elapsed();
+        self.timer = Instant::now();
+    }
+
+    /// Skip the time since the previous poll, which was spent paused.
+    fn hold(&mut self) {
+        self.timer = Instant::now();
+    }
+
+    /// Whether the track played past its length, so it must have started over.
+    ///
+    /// The play time is allowed to run a little past the length first, so that
+    /// the last moments of a track are not taken for a repeat while the player
+    /// has yet to report the next one.
+    fn started_over(&self) -> bool {
+        self.length
+            .is_some_and(|length| self.play_time >= length + RESTART_GRACE)
+    }
+}
+
+/// Decide whether a track that has been playing for `play_time` is a scrobble.
+///
+/// A track counts as played once it is longer than 30 seconds and has been
+/// playing for at least half its length, or for 4 minutes, whichever occurs
+/// earlier. The `min-play-time` config option replaces the play time that is
+/// required; tracks that are too short stay out either way.
+fn should_scrobble(config: &Config, length: Option<Duration>, play_time: Duration) -> bool {
+    if length.is_some_and(|length| length <= MIN_LENGTH) {
+        return false;
+    }
+
+    let required = config.min_play_time.unwrap_or_else(|| match length {
+        Some(length) => (length / 2).min(MAX_PLAY_TIME),
+        // Neither rule can be checked without a length, but a track that played
+        // for 4 minutes satisfies both, however long it turns out to be
+        None => MAX_PLAY_TIME,
+    });
+
+    play_time >= required
+}
+
+/// Start following a track: announce it and tell the services it is playing.
+fn start_track(
+    config: &Config,
+    services: &[Service],
+    track: Track,
+    metadata: &Metadata,
+    length: Option<Duration>,
+) -> Playing {
+    print!(
+        "----\n\
+        Now playing: {} - {}",
+        track.artist(),
+        track.title(),
+    );
+    if let Some(album) = track.album() {
+        print!(" ({album}");
+        if let Some(album_artist) = track.album_artist() {
+            print!(" by {album_artist}");
         }
-    })
+        print!(")");
+    }
+    println!();
+
+    let submission = match filter_metadata(config, track.clone(), metadata) {
+        Ok(FilterResult::Filtered(track)) | Ok(FilterResult::NotFiltered(track)) => Some(track),
+        Ok(FilterResult::Ignored) => {
+            println!("Track ignored");
+            None
+        }
+        Err(err) => {
+            eprintln!("{:?}", err);
+            None
+        }
+    };
+
+    if let Some(submission) = submission.as_ref() {
+        for service in services.iter() {
+            match service.now_playing(submission, length) {
+                Ok(()) => println!("Status updated on {} successfully", service),
+                Err(err) => eprintln!("{:?}", err),
+            }
+        }
+    }
+
+    let now = Instant::now();
+
+    Playing {
+        track,
+        submission,
+        length,
+        start: SystemTime::now(),
+        play_time: Duration::from_secs(0),
+        timer: now,
+        status_updated: now,
+        submitted: false,
+    }
+}
+
+/// Renew the "now playing" status of the services where it expires, so that it
+/// keeps showing for as long as the track is playing.
+fn refresh_now_playing(services: &[Service], playing: &mut Playing) {
+    if playing.status_updated.elapsed() < NOW_PLAYING_INTERVAL {
+        return;
+    }
+
+    playing.status_updated = Instant::now();
+
+    let Some(track) = playing.submission.as_ref() else {
+        return;
+    };
+
+    for service in services
+        .iter()
+        .filter(|service| service.now_playing_expires())
+    {
+        // The status was announced when the track started, so only report failures
+        if let Err(err) = service.now_playing(track, playing.length) {
+            eprintln!("{:?}", err);
+        }
+    }
+}
+
+/// Submit a track to the services that scrobble it as soon as it has been
+/// played long enough.
+fn submit_when_played(config: &Config, services: &[Service], playing: &mut Playing) {
+    if playing.submitted || !should_scrobble(config, playing.length, playing.play_time) {
+        return;
+    }
+
+    playing.submitted = true;
+
+    let Some(track) = playing.submission.as_ref() else {
+        return;
+    };
+
+    for service in services
+        .iter()
+        .filter(|service| !service.scrobbles_at_track_end())
+    {
+        match service.submit(track, playing.start, playing.length) {
+            Ok(()) => println!("Track submitted to {} successfully", service),
+            Err(err) => eprintln!("{:?}", err),
+        }
+    }
+}
+
+/// Submit a track that has finished playing to the services that wait for it,
+/// timestamped with the time and date the track started playing.
+fn finish_track(config: &Config, services: &[Service], playing: Playing) {
+    if !should_scrobble(config, playing.length, playing.play_time) {
+        return;
+    }
+
+    let Some(track) = playing.submission.as_ref() else {
+        return;
+    };
+
+    for service in services
+        .iter()
+        .filter(|service| service.scrobbles_at_track_end())
+    {
+        match service.submit(track, playing.start, playing.length) {
+            Ok(()) => println!("Track submitted to {} successfully", service),
+            Err(err) => eprintln!("{:?}", err),
+        }
+    }
 }
 
 pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
@@ -52,15 +246,15 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
 
     println!("Found active player {}", player.identity());
 
-    let mut previous_track = Track::default();
-
-    let mut timer = Instant::now();
-    let mut current_play_time = Duration::from_secs(0);
-    let mut scrobbled_current_song = false;
-    let mut track_start = SystemTime::now();
+    let mut playing: Option<Playing> = None;
 
     loop {
-        if !player::is_active(&player) {
+        if !player.is_running() {
+            // The track cannot be resumed, so it ends here
+            if let Some(track) = playing.take() {
+                finish_track(&config, &services, track);
+            }
+
             println!(
                 "----\n\
                 Player {} stopped, looking for a new MPRIS player...",
@@ -71,11 +265,7 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
 
             println!("Found active player {}", player.identity());
 
-            previous_track.clear();
-
-            timer = Instant::now();
-            current_play_time = Duration::from_secs(0);
-            scrobbled_current_song = false;
+            continue;
         }
 
         let status = player
@@ -83,18 +273,42 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
             .map_err(|err| anyhow!("{}", err))
             .context("Failed to retrieve playback status");
 
-        match status {
-            Ok(PlaybackStatus::Playing) => {}
-            Ok(_) => {
-                thread::sleep(POLL_INTERVAL);
-                continue;
-            }
+        let status = match status {
+            Ok(status) => status,
             Err(err) => {
                 eprintln!("{:?}", err);
 
                 thread::sleep(POLL_INTERVAL);
                 continue;
             }
+        };
+
+        if status != PlaybackStatus::Playing {
+            // A paused track picks up where it left off; a stopped one does not,
+            // and neither does one on a player that another player takes over from
+            let takeover = player::find_active(&config, &finder)
+                .filter(|other| other.bus_name() != player.bus_name());
+
+            if status == PlaybackStatus::Stopped || takeover.is_some() {
+                if let Some(track) = playing.take() {
+                    finish_track(&config, &services, track);
+                }
+            } else if let Some(track) = playing.as_mut() {
+                track.hold();
+            }
+
+            if let Some(takeover) = takeover {
+                player = takeover;
+
+                println!(
+                    "----\n\
+                    Found active player {}",
+                    player.identity()
+                );
+            }
+
+            thread::sleep(POLL_INTERVAL);
+            continue;
         }
 
         let metadata = player
@@ -114,87 +328,125 @@ pub fn run(config: Config, services: Vec<Service>) -> Result<()> {
 
         let current_track = Track::from_metadata(&metadata);
 
-        let length = metadata
-            .length()
-            .and_then(|length| if length.is_zero() { None } else { Some(length) });
+        // A player that does not know the length reports it as zero
+        let length = metadata.length().filter(|length| !length.is_zero());
 
-        if current_track == previous_track {
-            if !scrobbled_current_song {
-                let min_play_time = get_min_play_time(&config, length.unwrap_or(MIN_LENGTH));
-
-                if length.map(|length| length > MIN_LENGTH).unwrap_or(true)
-                    && current_play_time > min_play_time
-                {
-                    let track_start = config
-                        .use_track_start_timestamp
-                        .unwrap_or(false)
-                        .then_some(&track_start);
-
-                    match filter_metadata(&config, current_track, &metadata) {
-                        Ok(FilterResult::Filtered(track))
-                        | Ok(FilterResult::NotFiltered(track)) => {
-                            for service in services.iter() {
-                                match service.submit(&track, track_start) {
-                                    Ok(()) => {
-                                        println!("Track submitted to {} successfully", service)
-                                    }
-                                    Err(err) => eprintln!("{:?}", err),
-                                }
-                            }
-                        }
-                        Ok(FilterResult::Ignored) => {}
-                        Err(err) => eprintln!("{:?}", err),
-                    }
-
-                    scrobbled_current_song = true;
-                }
-            } else if length
-                .map(|length| current_play_time >= length)
-                .unwrap_or(false)
-            {
-                current_play_time = Duration::from_secs(0);
-                scrobbled_current_song = false;
-                track_start = SystemTime::now();
+        let ended = match playing.as_mut() {
+            // A different track means the previous one ended
+            Some(track) if track.track != current_track => true,
+            Some(track) => {
+                track.tick();
+                // The track played all the way through and started over
+                track.started_over()
             }
+            None => false,
+        };
 
-            current_play_time += timer.elapsed();
-            timer = Instant::now();
-        } else {
-            previous_track.clone_from(&current_track);
-
-            timer = Instant::now();
-            current_play_time = Duration::from_secs(0);
-            scrobbled_current_song = false;
-            track_start = SystemTime::now();
-
-            print!(
-                "----\n\
-                Now playing: {} - {}",
-                current_track.artist(),
-                current_track.title(),
-            );
-            if let Some(album) = current_track.album() {
-                print!(" ({album}");
-                if let Some(album_artist) = current_track.album_artist() {
-                    print!(" by {album_artist}");
-                }
-                println!(")");
-            }
-
-            match filter_metadata(&config, current_track, &metadata) {
-                Ok(FilterResult::Filtered(track)) | Ok(FilterResult::NotFiltered(track)) => {
-                    for service in services.iter() {
-                        match service.now_playing(&track) {
-                            Ok(()) => println!("Status updated on {} successfully", service),
-                            Err(err) => eprintln!("{:?}", err),
-                        }
-                    }
-                }
-                Ok(FilterResult::Ignored) => println!("Track ignored"),
-                Err(err) => eprintln!("{:?}", err),
-            }
+        if ended && let Some(track) = playing.take() {
+            finish_track(&config, &services, track);
         }
 
+        let playing = playing.get_or_insert_with(|| {
+            start_track(&config, &services, current_track, &metadata, length)
+        });
+
+        submit_when_played(&config, &services, playing);
+        refresh_now_playing(&services, playing);
+
         thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECOND: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn test_should_scrobble_short_track() {
+        let config = Config::default();
+
+        // A track of 30 seconds or shorter is never a scrobble, however long it plays
+
+        let length = Some(MIN_LENGTH);
+
+        assert!(!should_scrobble(&config, length, MIN_LENGTH));
+        assert!(!should_scrobble(&config, length, MAX_PLAY_TIME));
+
+        // A track just over 30 seconds is, once half of it has played
+
+        let length = Some(MIN_LENGTH + SECOND);
+
+        assert!(!should_scrobble(&config, length, MIN_LENGTH / 2));
+        assert!(should_scrobble(&config, length, MIN_LENGTH / 2 + SECOND));
+    }
+
+    #[test]
+    fn test_should_scrobble_half_the_length() {
+        let config = Config::default();
+
+        // A track shorter than 8 minutes is a scrobble after half its length
+
+        let length = Duration::from_secs(5 * 60);
+
+        assert!(!should_scrobble(&config, Some(length), length / 2 - SECOND));
+        assert!(should_scrobble(&config, Some(length), length / 2));
+    }
+
+    #[test]
+    fn test_should_scrobble_four_minutes() {
+        let config = Config::default();
+
+        // A track longer than 8 minutes is a scrobble after 4 minutes, well
+        // before half of it has played
+
+        let length = Duration::from_secs(20 * 60);
+
+        assert!(!should_scrobble(
+            &config,
+            Some(length),
+            MAX_PLAY_TIME - SECOND
+        ));
+        assert!(should_scrobble(&config, Some(length), MAX_PLAY_TIME));
+    }
+
+    #[test]
+    fn test_should_scrobble_without_length() {
+        let config = Config::default();
+
+        // Without a length, only the 4 minute rule can be applied
+
+        assert!(!should_scrobble(&config, None, MAX_PLAY_TIME - SECOND));
+        assert!(should_scrobble(&config, None, MAX_PLAY_TIME));
+    }
+
+    #[test]
+    fn test_should_scrobble_min_play_time() {
+        let config = Config {
+            min_play_time: Some(Duration::from_secs(10)),
+            ..Default::default()
+        };
+
+        // A configured minimum play time replaces the half/4 minute rule
+
+        assert!(!should_scrobble(
+            &config,
+            Some(Duration::from_secs(5 * 60)),
+            Duration::from_secs(9)
+        ));
+        assert!(should_scrobble(
+            &config,
+            Some(Duration::from_secs(5 * 60)),
+            Duration::from_secs(10)
+        ));
+
+        // But tracks that are too short stay out
+
+        assert!(!should_scrobble(
+            &config,
+            Some(MIN_LENGTH),
+            Duration::from_secs(10)
+        ));
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -71,25 +71,28 @@ fn is_ignorelisted(config: &Config, player: &Player) -> bool {
     false
 }
 
+/// Look for a (whitelisted, not ignorelisted) player that is playing right now.
+pub fn find_active(config: &Config, finder: &PlayerFinder) -> Option<Player> {
+    let players = finder.iter_players().ok()?;
+
+    for player in players {
+        if let Ok(player) = player
+            && is_active(&player)
+            && is_whitelisted(config, &player)
+            && !is_ignorelisted(config, &player)
+        {
+            return Some(player);
+        }
+    }
+
+    None
+}
+
 /// Wait for any (whitelisted, not ignorelisted) player to become active again.
 pub fn wait_for_player(config: &Config, finder: &PlayerFinder) -> Player {
     loop {
-        let players = match finder.iter_players() {
-            Ok(players) => players,
-            _ => {
-                thread::sleep(INIT_WAIT_TIME);
-                continue;
-            }
-        };
-
-        for player in players {
-            if let Ok(player) = player
-                && is_active(&player)
-                && is_whitelisted(config, &player)
-                && !is_ignorelisted(config, &player)
-            {
-                return player;
-            }
+        if let Some(player) = find_active(config, finder) {
+            return player;
         }
 
         thread::sleep(INIT_WAIT_TIME);

--- a/src/service.rs
+++ b/src/service.rs
@@ -107,13 +107,6 @@ impl Service {
         services
     }
 
-    /// Whether a track is scrobbled once it has finished playing, timestamped
-    /// with the time it started, instead of as soon as it has been played long
-    /// enough. Only Last.fm takes a timestamp for a scrobble.
-    pub fn scrobbles_at_track_end(&self) -> bool {
-        matches!(self, Self::LastFM(_))
-    }
-
     /// Whether the "now playing" status expires while the track is still
     /// playing, so it has to be renewed to stay visible for the whole track.
     pub fn now_playing_expires(&self) -> bool {
@@ -137,7 +130,8 @@ impl Service {
         Ok(())
     }
 
-    /// Scrobble a track that started playing at `track_start`.
+    /// Scrobble a track that started playing at `track_start`. Only Last.fm
+    /// takes a timestamp; ListenBrainz records the listen at submission time.
     pub fn submit(
         &self,
         track: &Track,
@@ -156,7 +150,6 @@ impl Service {
                     .with_context(|| format!("Failed to submit track to {}", self))?;
             }
             Self::ListenBrainz { client, .. } => {
-                // ListenBrainz listens are recorded at the time they are submitted
                 client
                     .listen(track.artist(), track.title(), track.album())
                     .with_context(|| format!("Failed to submit track to {}", self))?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -20,8 +20,6 @@ use anyhow::{Context, Result, anyhow};
 
 use listenbrainz::ListenBrainz;
 
-use rustfm_scrobble_proxy::{Scrobble, Scrobbler};
-
 mod lastfm;
 
 use crate::config::secrets::Secret;
@@ -30,7 +28,7 @@ use crate::track::Track;
 
 /// Represents a music scrobbling service.
 pub enum Service {
-    LastFM(Scrobbler),
+    LastFM(lastfm::Client),
     ListenBrainz {
         client: ListenBrainz,
         is_default: bool,
@@ -42,12 +40,16 @@ impl Service {
     fn lastfm(config: &Config) -> Result<Option<Self>> {
         match (&config.lastfm_key, &config.lastfm_secret) {
             (Some(key), Some(secret)) => {
-                let mut scrobbler = Scrobbler::new(&key.get()?, &secret.get()?);
+                let (key, secret) = (key.get()?, secret.get()?);
 
-                lastfm::authenticate(&mut scrobbler)
+                let session_key = lastfm::authenticate(&key, &secret)
                     .context("Failed to authenticate with Last.fm")?;
 
-                Ok(Some(Self::LastFM(scrobbler)))
+                Ok(Some(Self::LastFM(lastfm::Client::new(
+                    &key,
+                    &secret,
+                    &session_key,
+                ))))
             }
             (None, None) => Ok(None),
             _ => Err(anyhow!("Last.fm API key or API secret are missing")),
@@ -108,11 +110,9 @@ impl Service {
     /// Submit a "now playing" request.
     pub fn now_playing(&self, track: &Track) -> Result<()> {
         match self {
-            Self::LastFM(scrobbler) => {
-                let scrobble = Scrobble::new(track.artist(), track.title(), track.album());
-
-                scrobbler
-                    .now_playing(&scrobble)
+            Self::LastFM(client) => {
+                client
+                    .now_playing(track)
                     .with_context(|| format!("Failed to update status on {}", self))?;
             }
             Self::ListenBrainz { client, .. } => {
@@ -127,19 +127,17 @@ impl Service {
     /// Scrobble a track.
     pub fn submit(&self, track: &Track, track_start: Option<&SystemTime>) -> Result<()> {
         match self {
-            Self::LastFM(scrobbler) => {
-                let mut scrobble = Scrobble::new(track.artist(), track.title(), track.album());
-
-                if let Some(track_start) = track_start {
-                    let timestamp = track_start
+            Self::LastFM(client) => {
+                let timestamp = match track_start {
+                    Some(track_start) => track_start
                         .duration_since(UNIX_EPOCH)
-                        .context("Track started before UNIX epoch")?;
+                        .context("Track started before UNIX epoch")?
+                        .as_secs(),
+                    None => lastfm::now()?,
+                };
 
-                    scrobble.with_timestamp(timestamp.as_secs());
-                }
-
-                scrobbler
-                    .scrobble(&scrobble)
+                client
+                    .scrobble(track, timestamp)
                     .with_context(|| format!("Failed to submit track to {}", self))?;
             }
             Self::ListenBrainz { client, .. } => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::fmt::{self, Write};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow};
 
@@ -107,12 +107,25 @@ impl Service {
         services
     }
 
+    /// Whether a track is scrobbled once it has finished playing, timestamped
+    /// with the time it started, instead of as soon as it has been played long
+    /// enough. Only Last.fm takes a timestamp for a scrobble.
+    pub fn scrobbles_at_track_end(&self) -> bool {
+        matches!(self, Self::LastFM(_))
+    }
+
+    /// Whether the "now playing" status expires while the track is still
+    /// playing, so it has to be renewed to stay visible for the whole track.
+    pub fn now_playing_expires(&self) -> bool {
+        matches!(self, Self::LastFM(_))
+    }
+
     /// Submit a "now playing" request.
-    pub fn now_playing(&self, track: &Track) -> Result<()> {
+    pub fn now_playing(&self, track: &Track, length: Option<Duration>) -> Result<()> {
         match self {
             Self::LastFM(client) => {
                 client
-                    .now_playing(track)
+                    .now_playing(track, length)
                     .with_context(|| format!("Failed to update status on {}", self))?;
             }
             Self::ListenBrainz { client, .. } => {
@@ -124,23 +137,26 @@ impl Service {
         Ok(())
     }
 
-    /// Scrobble a track.
-    pub fn submit(&self, track: &Track, track_start: Option<&SystemTime>) -> Result<()> {
+    /// Scrobble a track that started playing at `track_start`.
+    pub fn submit(
+        &self,
+        track: &Track,
+        track_start: SystemTime,
+        length: Option<Duration>,
+    ) -> Result<()> {
         match self {
             Self::LastFM(client) => {
-                let timestamp = match track_start {
-                    Some(track_start) => track_start
-                        .duration_since(UNIX_EPOCH)
-                        .context("Track started before UNIX epoch")?
-                        .as_secs(),
-                    None => lastfm::now()?,
-                };
+                let timestamp = track_start
+                    .duration_since(UNIX_EPOCH)
+                    .context("Track started before UNIX epoch")?
+                    .as_secs();
 
                 client
-                    .scrobble(track, timestamp)
+                    .scrobble(track, timestamp, length)
                     .with_context(|| format!("Failed to submit track to {}", self))?;
             }
             Self::ListenBrainz { client, .. } => {
+                // ListenBrainz listens are recorded at the time they are submitted
                 client
                     .listen(track.artist(), track.title(), track.album())
                     .with_context(|| format!("Failed to submit track to {}", self))?;

--- a/src/service/lastfm.rs
+++ b/src/service/lastfm.rs
@@ -15,51 +15,235 @@
 use std::fs::{self, Permissions};
 use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use rustfm_scrobble_proxy::Scrobbler;
 
 use rpassword::read_password;
 
+use serde::Deserialize;
+
 use crate::config::config_dir;
+use crate::track::Track;
 
 const SESSION_FILE: &str = "session";
 
+const API_URL: &str = "https://ws.audioscrobbler.com/2.0/?format=json";
+
 /// Authenticate with Last.fm either using an existing
-/// session file or by logging in.
-pub fn authenticate(scrobbler: &mut Scrobbler) -> Result<()> {
+/// session file or by logging in, and return the session key.
+pub fn authenticate(api_key: &str, api_secret: &str) -> Result<String> {
     let mut path = config_dir()?;
     path.push(SESSION_FILE);
 
     if let Ok(session_key) = fs::read_to_string(&path) {
         // TODO: validate session
-        scrobbler.authenticate_with_session_key(&session_key);
-    } else {
-        let mut input = String::new();
-
-        print!(
-            "Log in to Last.fm\n\
-            Username: "
-        );
-        io::stdout().flush()?;
-
-        io::stdin().read_line(&mut input)?;
-        input.pop();
-        let username = input.clone();
-
-        input.clear();
-
-        print!("Password: ");
-        io::stdout().flush()?;
-
-        let password = read_password().context("Failed to read password")?;
-
-        let session_response = scrobbler.authenticate_with_password(&username, &password)?;
-
-        let _ = fs::write(&path, session_response.key);
-        let _ = fs::set_permissions(&path, Permissions::from_mode(0o600));
+        return Ok(session_key);
     }
 
-    Ok(())
+    let mut scrobbler = Scrobbler::new(api_key, api_secret);
+
+    let mut input = String::new();
+
+    print!(
+        "Log in to Last.fm\n\
+        Username: "
+    );
+    io::stdout().flush()?;
+
+    io::stdin().read_line(&mut input)?;
+    input.pop();
+    let username = input.clone();
+
+    input.clear();
+
+    print!("Password: ");
+    io::stdout().flush()?;
+
+    let password = read_password().context("Failed to read password")?;
+
+    let session_response = scrobbler.authenticate_with_password(&username, &password)?;
+
+    let _ = fs::write(&path, &session_response.key);
+    let _ = fs::set_permissions(&path, Permissions::from_mode(0o600));
+
+    Ok(session_response.key)
+}
+
+/// An error returned by the Last.fm API.
+#[derive(Deserialize)]
+struct ApiError {
+    error: u32,
+    message: String,
+}
+
+/// A minimal Last.fm scrobbling client.
+///
+/// This exists instead of `rustfm_scrobble_proxy::Scrobbler` because that crate
+/// has no way to submit the `albumArtist` parameter, without which Last.fm
+/// assumes the album artist equals the track artist. That splits compilations
+/// and DJ mixes into a separate album per track artist.
+pub struct Client {
+    api_key: String,
+    api_secret: String,
+    session_key: String,
+}
+
+impl Client {
+    pub fn new(api_key: &str, api_secret: &str, session_key: &str) -> Self {
+        Self {
+            api_key: api_key.to_owned(),
+            api_secret: api_secret.to_owned(),
+            session_key: session_key.trim().to_owned(),
+        }
+    }
+
+    /// Submit a "now playing" request for a track.
+    pub fn now_playing(&self, track: &Track) -> Result<()> {
+        self.request("track.updateNowPlaying", track_params(track))
+    }
+
+    /// Scrobble a track, played at `timestamp` seconds since the UNIX epoch.
+    pub fn scrobble(&self, track: &Track, timestamp: u64) -> Result<()> {
+        let mut params = track_params(track);
+        params.push(("timestamp", timestamp.to_string()));
+
+        self.request("track.scrobble", params)
+    }
+
+    /// Send a signed, authenticated POST request to the Last.fm API.
+    fn request(&self, method: &str, mut params: Vec<(&str, String)>) -> Result<()> {
+        params.push(("method", method.to_owned()));
+        params.push(("api_key", self.api_key.clone()));
+        params.push(("sk", self.session_key.clone()));
+        params.push(("api_sig", signature(&params, &self.api_secret)));
+
+        let response = attohttpc::post(API_URL)
+            .form(&params)
+            .context("Failed to encode request")?
+            .send()
+            .context("Failed to send request")?;
+
+        let status = response.status();
+        let body = response.text().context("Failed to read response")?;
+
+        if let Ok(err) = serde_json::from_str::<ApiError>(&body) {
+            bail!("Last.fm API error {}: {}", err.error, err.message);
+        }
+
+        if !status.is_success() {
+            bail!("Last.fm returned status {status}");
+        }
+
+        Ok(())
+    }
+}
+
+/// Build the track metadata parameters shared by scrobbles and status updates.
+fn track_params(track: &Track) -> Vec<(&'static str, String)> {
+    let mut params = vec![
+        ("artist", track.artist().to_owned()),
+        ("track", track.title().to_owned()),
+    ];
+
+    if let Some(album) = track.album() {
+        params.push(("album", album.to_owned()));
+    }
+
+    // Last.fm only wants `albumArtist` when it differs from the track artist
+    if let Some(album_artist) = track.album_artist().filter(|a| *a != track.artist()) {
+        params.push(("albumArtist", album_artist.to_owned()));
+    }
+
+    params
+}
+
+/// Compute the Last.fm API signature: the parameters concatenated in order of
+/// their keys, followed by the API secret, hashed with MD5.
+fn signature(params: &[(&str, String)], api_secret: &str) -> String {
+    let mut params: Vec<_> = params.iter().collect();
+    params.sort_by_key(|(key, _)| *key);
+
+    let mut sig = String::new();
+    for (key, value) in params {
+        sig.push_str(key);
+        sig.push_str(value);
+    }
+    sig.push_str(api_secret);
+
+    format!("{:x}", md5::compute(sig))
+}
+
+/// The current time in seconds since the UNIX epoch.
+pub fn now() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("Current time is before the UNIX epoch")?
+        .as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signature() {
+        // Parameters are sorted by key, concatenated as key/value pairs and
+        // suffixed with the API secret before hashing
+        let params = [
+            ("track", "Psycho".to_owned()),
+            ("api_key", "key".to_owned()),
+            ("artist", "Dimension".to_owned()),
+        ];
+
+        let expected = md5::compute("api_keykeyartistDimensiontrackPsychosecret");
+
+        assert_eq!(signature(&params, "secret"), format!("{expected:x}"));
+    }
+
+    #[test]
+    fn test_track_params() {
+        // A track without an album or album artist only submits artist and title
+
+        let track = Track::new("Dimension", "Psycho", None);
+
+        assert_eq!(
+            track_params(&track),
+            vec![
+                ("artist", "Dimension".to_owned()),
+                ("track", "Psycho".to_owned()),
+            ]
+        );
+
+        // An album artist that differs from the track artist is submitted
+
+        let track = Track::new("The Herbaliser", "Wall Crawling", Some("The K&D Sessions"))
+            .with_album_artist(Some("Kruder & Dorfmeister"));
+
+        assert_eq!(
+            track_params(&track),
+            vec![
+                ("artist", "The Herbaliser".to_owned()),
+                ("track", "Wall Crawling".to_owned()),
+                ("album", "The K&D Sessions".to_owned()),
+                ("albumArtist", "Kruder & Dorfmeister".to_owned()),
+            ]
+        );
+
+        // An album artist equal to the track artist is redundant and omitted
+
+        let track = Track::new("Men At Work", "Down Under", Some("Business As Usual"))
+            .with_album_artist(Some("Men At Work"));
+
+        assert_eq!(
+            track_params(&track),
+            vec![
+                ("artist", "Men At Work".to_owned()),
+                ("track", "Down Under".to_owned()),
+                ("album", "Business As Usual".to_owned()),
+            ]
+        );
+    }
 }

--- a/src/service/lastfm.rs
+++ b/src/service/lastfm.rs
@@ -15,7 +15,7 @@
 use std::fs::{self, Permissions};
 use std::io::{self, Write};
 use std::os::unix::fs::PermissionsExt;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 
@@ -101,13 +101,17 @@ impl Client {
     }
 
     /// Submit a "now playing" request for a track.
-    pub fn now_playing(&self, track: &Track) -> Result<()> {
-        self.request("track.updateNowPlaying", track_params(track))
+    ///
+    /// Last.fm keeps the status up for the length of the track when it is known,
+    /// so the length is submitted along with it.
+    pub fn now_playing(&self, track: &Track, length: Option<Duration>) -> Result<()> {
+        self.request("track.updateNowPlaying", track_params(track, length))
     }
 
-    /// Scrobble a track, played at `timestamp` seconds since the UNIX epoch.
-    pub fn scrobble(&self, track: &Track, timestamp: u64) -> Result<()> {
-        let mut params = track_params(track);
+    /// Scrobble a track that started playing at `timestamp` seconds since the
+    /// UNIX epoch.
+    pub fn scrobble(&self, track: &Track, timestamp: u64, length: Option<Duration>) -> Result<()> {
+        let mut params = track_params(track, length);
         params.push(("timestamp", timestamp.to_string()));
 
         self.request("track.scrobble", params)
@@ -142,7 +146,7 @@ impl Client {
 }
 
 /// Build the track metadata parameters shared by scrobbles and status updates.
-fn track_params(track: &Track) -> Vec<(&'static str, String)> {
+fn track_params(track: &Track, length: Option<Duration>) -> Vec<(&'static str, String)> {
     let mut params = vec![
         ("artist", track.artist().to_owned()),
         ("track", track.title().to_owned()),
@@ -155,6 +159,10 @@ fn track_params(track: &Track) -> Vec<(&'static str, String)> {
     // Last.fm only wants `albumArtist` when it differs from the track artist
     if let Some(album_artist) = track.album_artist().filter(|a| *a != track.artist()) {
         params.push(("albumArtist", album_artist.to_owned()));
+    }
+
+    if let Some(length) = length {
+        params.push(("duration", length.as_secs().to_string()));
     }
 
     params
@@ -174,14 +182,6 @@ fn signature(params: &[(&str, String)], api_secret: &str) -> String {
     sig.push_str(api_secret);
 
     format!("{:x}", md5::compute(sig))
-}
-
-/// The current time in seconds since the UNIX epoch.
-pub fn now() -> Result<u64> {
-    Ok(SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .context("Current time is before the UNIX epoch")?
-        .as_secs())
 }
 
 #[cfg(test)]
@@ -205,12 +205,12 @@ mod tests {
 
     #[test]
     fn test_track_params() {
-        // A track without an album or album artist only submits artist and title
+        // A track without an album, album artist or length only submits artist and title
 
         let track = Track::new("Dimension", "Psycho", None);
 
         assert_eq!(
-            track_params(&track),
+            track_params(&track, None),
             vec![
                 ("artist", "Dimension".to_owned()),
                 ("track", "Psycho".to_owned()),
@@ -223,7 +223,7 @@ mod tests {
             .with_album_artist(Some("Kruder & Dorfmeister"));
 
         assert_eq!(
-            track_params(&track),
+            track_params(&track, None),
             vec![
                 ("artist", "The Herbaliser".to_owned()),
                 ("track", "Wall Crawling".to_owned()),
@@ -238,11 +238,24 @@ mod tests {
             .with_album_artist(Some("Men At Work"));
 
         assert_eq!(
-            track_params(&track),
+            track_params(&track, None),
             vec![
                 ("artist", "Men At Work".to_owned()),
                 ("track", "Down Under".to_owned()),
                 ("album", "Business As Usual".to_owned()),
+            ]
+        );
+
+        // A known track length is submitted as the duration, in seconds
+
+        let track = Track::new("Dimension", "Psycho", None);
+
+        assert_eq!(
+            track_params(&track, Some(Duration::from_millis(215_500))),
+            vec![
+                ("artist", "Dimension".to_owned()),
+                ("track", "Psycho".to_owned()),
+                ("duration", "215".to_owned()),
             ]
         );
     }

--- a/src/track.rs
+++ b/src/track.rs
@@ -20,7 +20,7 @@ fn non_empty(value: Option<&str>) -> Option<String> {
     value.filter(|value| !value.is_empty()).map(str::to_owned)
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct Track {
     artist: String,
     title: String,
@@ -59,20 +59,6 @@ impl Track {
     pub fn with_album_artist(mut self, album_artist: Option<&str>) -> Self {
         self.album_artist = non_empty(album_artist);
         self
-    }
-
-    pub fn clear(&mut self) {
-        self.artist.clear();
-        self.title.clear();
-        self.album.take();
-        self.album_artist.take();
-    }
-
-    pub fn clone_from(&mut self, other: &Self) {
-        self.artist.clone_from(&other.artist);
-        self.title.clone_from(&other.title);
-        self.album.clone_from(&other.album);
-        self.album_artist.clone_from(&other.album_artist);
     }
 
     pub fn from_metadata(metadata: &Metadata) -> Self {

--- a/src/track.rs
+++ b/src/track.rs
@@ -15,11 +15,17 @@
 
 use mpris::Metadata;
 
+/// Turn an optional string into an owned one, treating the empty string as absent.
+fn non_empty(value: Option<&str>) -> Option<String> {
+    value.filter(|value| !value.is_empty()).map(str::to_owned)
+}
+
 #[derive(Debug, Default, PartialEq)]
 pub struct Track {
     artist: String,
     title: String,
     album: Option<String>,
+    album_artist: Option<String>,
 }
 
 impl Track {
@@ -35,30 +41,38 @@ impl Track {
         self.album.as_deref()
     }
 
+    /// The artist the album is credited to, which can differ from the track
+    /// artist on compilations, DJ mixes and other various-artists releases.
+    pub fn album_artist(&self) -> Option<&str> {
+        self.album_artist.as_deref()
+    }
+
     pub fn new(artist: &str, title: &str, album: Option<&str>) -> Self {
         Self {
             artist: artist.to_owned(),
             title: title.to_owned(),
-            album: album.and_then(|album| {
-                if !album.is_empty() {
-                    Some(album.to_owned())
-                } else {
-                    None
-                }
-            }),
+            album: non_empty(album),
+            album_artist: None,
         }
+    }
+
+    pub fn with_album_artist(mut self, album_artist: Option<&str>) -> Self {
+        self.album_artist = non_empty(album_artist);
+        self
     }
 
     pub fn clear(&mut self) {
         self.artist.clear();
         self.title.clear();
         self.album.take();
+        self.album_artist.take();
     }
 
     pub fn clone_from(&mut self, other: &Self) {
         self.artist.clone_from(&other.artist);
         self.title.clone_from(&other.title);
         self.album.clone_from(&other.album);
+        self.album_artist.clone_from(&other.album_artist);
     }
 
     pub fn from_metadata(metadata: &Metadata) -> Self {
@@ -71,18 +85,20 @@ impl Track {
 
         let title = metadata.title().unwrap_or("").to_owned();
 
-        let album = metadata.album_name().and_then(|album| {
-            if !album.is_empty() {
-                Some(album.to_owned())
-            } else {
-                None
-            }
-        });
+        let album = non_empty(metadata.album_name());
+
+        let album_artist = non_empty(
+            metadata
+                .album_artists()
+                .as_ref()
+                .and_then(|artists| artists.first().copied()),
+        );
 
         Self {
             artist,
             title,
             album,
+            album_artist,
         }
     }
 }
@@ -107,6 +123,32 @@ mod tests {
         assert_eq!(
             Track::new("Dimension", "Psycho", Some("Organ")).album(),
             Some("Organ")
+        );
+
+        // An empty album artist should result in `None` for `Track::album_artist()`
+
+        assert_eq!(
+            Track::new(
+                "The Herbaliser",
+                "Wall Crawling Giant Insect Breaks",
+                Some("The K&D Sessions")
+            )
+            .with_album_artist(Some(""))
+            .album_artist(),
+            None
+        );
+
+        // A nonempty album artist should result in `Some` for `Track::album_artist()`
+
+        assert_eq!(
+            Track::new(
+                "The Herbaliser",
+                "Wall Crawling Giant Insect Breaks",
+                Some("The K&D Sessions")
+            )
+            .with_album_artist(Some("Kruder & Dorfmeister"))
+            .album_artist(),
+            Some("Kruder & Dorfmeister")
         );
     }
 
@@ -167,5 +209,35 @@ mod tests {
         let track_with_album = Track::from_metadata(&metadata_with_album);
 
         assert_eq!(track_with_album.album(), Some("Business As Usual"));
+        assert_eq!(track_with_album.album_artist(), None);
+
+        // Metadata with an album artist should result in a `Some` for `Track::album_artist()`
+
+        let mut metadata_with_album_artist = HashMap::new();
+        metadata_with_album_artist.insert(
+            "xesam:artist".to_owned(),
+            MetadataValue::Array(vec![MetadataValue::String("The Herbaliser".to_owned())]),
+        );
+        metadata_with_album_artist.insert(
+            "xesam:title".to_owned(),
+            MetadataValue::String("Wall Crawling Giant Insect Breaks".to_owned()),
+        );
+        metadata_with_album_artist.insert(
+            "xesam:album".to_owned(),
+            MetadataValue::String("The K&D Sessions".to_owned()),
+        );
+        metadata_with_album_artist.insert(
+            "xesam:albumArtist".to_owned(),
+            MetadataValue::Array(vec![MetadataValue::String(
+                "Kruder & Dorfmeister".to_owned(),
+            )]),
+        );
+        let metadata_with_album_artist = Metadata::from(metadata_with_album_artist);
+        let track_with_album_artist = Track::from_metadata(&metadata_with_album_artist);
+
+        assert_eq!(
+            track_with_album_artist.album_artist(),
+            Some("Kruder & Dorfmeister")
+        );
     }
 }


### PR DESCRIPTION
- Added the ability to submit the albumartist id3 tag to get correct tags on albums by VA or DJ Mixes
- Fixed the scrobble and now playing logic to follow last.fm's specifications:
> When is a scrobble a scrobble?
> A track should only be scrobbled when the following conditions have been met:
> The track must be longer than 30 seconds.
> And the track has been played for at least half its duration, or for 4 minutes (whichever occurs earlier.)
[Source](https://www.last.fm/api/scrobbling)

> [!NOTE]
> The entire code is generated by Opus 5. If the PR gets rejected on this basis alone, that's completely understandable. 
